### PR TITLE
Extend `RUPY` NPC to enable it to drop any item in the game

### DIFF
--- a/base/src/extend_RUPY_npc.c
+++ b/base/src/extend_RUPY_npc.c
@@ -1,0 +1,26 @@
+#include <stdint.h>
+
+uint32_t extend_RUPY_npc(uint32_t *addr) {
+  uint32_t rupy_type = addr[0x56];
+  switch (rupy_type) {
+  case 3:
+    return 9;
+  case 4:
+    return 0x1a;
+  case 5:
+    return 0x1b;
+  case 6:
+    return 0x81;
+  case 7:
+    return 0x82;
+  default:
+    // This allows the RUPY NPC to take the form of any item.
+    // Given an item id `id`, set rupy_type to `id | 0x8000` to make the RUPY
+    // NPC drop it.
+    // For example, to drop a sword (id = 3), set rupy_type to 0x8003.
+    if (rupy_type > 2 && rupy_type < 0xFFFF) {
+      return rupy_type & 0x7FFF;
+    }
+    return 0xffffffff;
+  }
+}

--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -34,6 +34,15 @@
 .close
 
 
+.open "../overlay/overlay_0029.bin", 0x0211F5C0 ; overlay 14 in ghidra
+    .arm
+    .org 0x213b0e8
+        .area 0x74, 0xFF
+            .importobj "src/extend_RUPY_npc.o"
+        .endarea
+.close
+
+
 .open "../overlay/overlay_0031.bin", 0x0211F5C0
     .arm
     .org 0x17420 + 0x0211F5C0 ;0x217bce0


### PR DESCRIPTION
The other half of this would be to hook into the roll-into-tree drop/dig spot functions to properly set `rupy_type` based on some metadata in the ZMB entry.