### PR TITLE
Make it possible to drop any item from trees

### DIFF
--- a/base/src/_additional_tree_items.asm
+++ b/base/src/_additional_tree_items.asm
@@ -1,0 +1,44 @@
+; Check if the ID from the ZMB file is higher than 0x7 (the max id in the vanilla rom)
+; If it is, return from here and continue executing the existing function.
+ldr r0, [r4, 0x6c]
+cmp r0, 0x7
+ble @@return
+
+; Otherwise, spawn a RUPY using the ZMB ID as the rupy_type.
+ldr r0, =0x2162c00
+ldr r0, [r0]
+ldrsh r1, [r4, 0x34]
+ldr r0, [r0]
+bl 0x2084c68
+add r0, sp, 0x4
+bl 0x20c14a0
+mvn r1, 0x0
+add r0, sp, 0x4
+str r1, [sp, 0x20]
+str r1, [sp, 0x24]
+bl 0x20c32e8
+
+; NOTE: this differs from the original RUPY spawning code. 
+; Instead of copying in a specific "RUPY type id", we're just passing the ZMB
+; item id with the MSB set
+ldr r0, [r4, 0x6c] ; just copy id into r0
+
+strh r0, [sp, 0x4]
+mov r1, 0x0
+str r1, [sp, 0x0]
+ldr r0, =0x2162c04
+ldr r0, [r0]
+ldr r1, =0x2162c18
+ldr r1, [r1]
+ldr r0, [r0, 0x0]
+add r2, sp, 0x144
+add r3, sp, 0x4
+bl 0x20c3fe8
+ldr r0, =0x2162c00
+ldr r0, [r0]
+ldrsh r1, [r4, 0x34]
+ldr r0, [r0, 0x0]
+mov r2, 0x1
+bl 0x2084c50
+
+@@return:

--- a/base/src/extend_RUPY_npc.c
+++ b/base/src/extend_RUPY_npc.c
@@ -1,0 +1,26 @@
+#include <stdint.h>
+
+uint32_t extend_RUPY_npc(uint32_t *addr) {
+  uint32_t rupy_type = addr[0x56];
+  switch (rupy_type) {
+  case 3:
+    return 9;
+  case 4:
+    return 0x1a;
+  case 5:
+    return 0x1b;
+  case 6:
+    return 0x81;
+  case 7:
+    return 0x82;
+  default:
+    // This allows the RUPY NPC to take the form of any item.
+    // Given an item id `id`, set rupy_type to `id | 0x8000` to make the RUPY
+    // NPC drop it.
+    // For example, to drop a sword (id = 3), set rupy_type to 0x8003.
+    if (rupy_type > 2 && rupy_type < 0xFFFF) {
+      return rupy_type & 0x7FFF;
+    }
+    return 0xffffffff;
+  }
+}

--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -34,6 +34,15 @@
 .close
 
 
+.open "../overlay/overlay_0029.bin", 0x0211F5C0 ; overlay 14 in ghidra
+    .arm
+    .org 0x213b0e8
+        .area 0x74, 0xFF
+            .importobj "src/extend_RUPY_npc.o"
+        .endarea
+.close
+
+
 .open "../overlay/overlay_0031.bin", 0x0211F5C0
     .arm
     .org 0x17420 + 0x0211F5C0 ;0x217bce0

--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -20,6 +20,12 @@
                 strlt r0,[r4,0x78] ; original instruction, do not change
                 bl faster_boat
                 pop pc
+
+            @check_additional_items_tree_drop:
+                .include "_additional_tree_items.asm"
+                ldr r0, [r4, 0x6c]
+                b 0x2162790
+
         .pool
         .endarea
 .close
@@ -48,5 +54,14 @@
     .org 0x17420 + 0x0211F5C0 ;0x217bce0
         .area 0x4
             bl @faster_boat
+        .endarea
+.close
+
+
+.open "../overlay/overlay_0037.bin", 0x0215b400
+    .arm
+    .org 0x216278c
+        .area 0x4, 0xff
+            b @check_additional_items_tree_drop
         .endarea
 .close


### PR DESCRIPTION
Builds on top of #6 to allowing a tree to drop any item. Note to do this, you must set the drop_id in the tree's ZMB entry to the item id you want to drop OR'd with 0x8000 (i.e. the 16-bit item_id you want with its MSB set).

Unfortunately I had to use assembly for this, as I needed to reuse existing code to do this. However, with the exception of one line, all of the assembly is based on existing routines, so we can treat it more or less as a black box.