### PR TITLE
Pin ndspy to working version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-add-repository https://dl.winehq.org/wine-builds/debian/
 RUN apt-get update && apt-get install -y winehq-stable
 # Install python dependencies
 RUN apt-get install -y python3-pip python3-pil
-RUN pip3 install click ndspy
+RUN pip3 install click ndspy==3.0.0
 ADD misc/* /app/
 ADD src/* /app/src/
 ADD Makefile /app

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "ndspy",
+        "ndspy==3.0.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
The recent 4.0.0 release introduced breaking changes to the `color` and `graphics2D` modules, which broke the `title_screen.py` script. The ndspy devs mention in the [release notes](https://github.com/RoadrunnerWMC/ndspy/releases/tag/v4.0.0) that the `ndspy.color` module is still unstable and may be reverted or experience more breaking changes, so in that case i think we'd better just pin it to the version we've been using instead of trying to keep up with API changes