### PR TITLE
Initial scaffolding for patcher

### DIFF
--- a/patcher/example.py
+++ b/patcher/example.py
@@ -1,0 +1,65 @@
+from typing import Union
+
+from patcher import settings
+from patcher.location_types import EventLocation, IslandShopLocation, MapObjectLocation
+
+LOCATIONS: dict[str, Union[EventLocation, IslandShopLocation, MapObjectLocation]] = {
+    "ocean_temple_first_chest": MapObjectLocation(
+        34, "Map/dngn_main/map00.bin/zmb/dngn_main_00.zmb"
+    ),
+    "mercay_island_first_npc": EventLocation(135, "English/Message/main_isl.bmg"),
+    "mercay_island_chest_on_small_island": MapObjectLocation(
+        54, "Map/isle_main/map02.bin/zmb/isle_main_02.zmb"
+    ),
+    "mercay_island_rollable_tree": MapObjectLocation(
+        25, "Map/isle_main/map02.bin/zmb/isle_main_02.zmb"
+    ),
+    "mercay_island_SE_cliff_chest_left": MapObjectLocation(
+        97, "Map/isle_main/map03.bin/zmb/isle_main_03.zmb"
+    ),
+    "mercay_island_SE_cliff_chest_right": MapObjectLocation(
+        98, "Map/isle_main/map03.bin/zmb/isle_main_03.zmb"
+    ),
+    "mercay_island_SE_cucco_chest": MapObjectLocation(
+        113, "Map/isle_main/map03.bin/zmb/isle_main_03.zmb"
+    ),
+    "mercay_island_shipyard_chest": MapObjectLocation(
+        2, "Map/isle_main/map16.bin/zmb/isle_main_16.zmb"
+    ),
+    "mercay_island_oshus_sword_chest": MapObjectLocation(
+        1, "Map/isle_main/map19.bin/zmb/isle_main_19.zmb"
+    ),
+    "mercay_island_shop_shield": IslandShopLocation(31, 0x217ECB4 - 0x217BCE0),
+    "mercay_island_shop_power_gem": IslandShopLocation(31, 0x217EC68 - 0x217BCE0),
+    "isle_ember_chest_near_flame_temple": MapObjectLocation(
+        74, "Map/isle_flame/map00.bin/zmb/isle_flame_00.zmb"
+    ),
+    "isle_ember_chest_on_northern_small_island": MapObjectLocation(
+        75, "Map/isle_flame/map00.bin/zmb/isle_flame_00.zmb"
+    ),
+    "flame_temple_first_floor_key_chest": MapObjectLocation(
+        26, "Map/dngn_flame/map00.bin/zmb/dngn_flame_00.zmb"
+    ),
+    "flame_temple_first_floor_red_rupee_chest": MapObjectLocation(
+        68, "Map/dngn_flame/map00.bin/zmb/dngn_flame_00.zmb"
+    ),
+    "flame_temple_second_floor_boomerang_chest": MapObjectLocation(
+        7, "Map/dngn_flame/map01.bin/zmb/dngn_flame_01.zmb"
+    ),
+    "flame_temple_third_floor_big_key_chest": MapObjectLocation(
+        15, "Map/dngn_flame/map02.bin/zmb/dngn_flame_02.zmb"
+    ),
+    "flame_temple_boss_chest": MapObjectLocation(
+        2, "Map/boss_flame/map00.bin/zmb/boss_flame_00.zmb"
+    ),
+}
+
+# Set every location to a gold rupee
+for _, location in LOCATIONS.items():
+    location.set_location(0x1B)
+
+EventLocation.save_all()
+IslandShopLocation.save_all()
+MapObjectLocation.save_all()
+
+settings.ROM.saveToFile("out.nds")

--- a/patcher/location_types/__init__.py
+++ b/patcher/location_types/__init__.py
@@ -1,0 +1,9 @@
+from .event import EventLocation
+from .island_shop import IslandShopLocation
+from .map_object import MapObjectLocation
+
+__all__ = [
+    "EventLocation",
+    "IslandShopLocation",
+    "MapObjectLocation",
+]

--- a/patcher/location_types/event.py
+++ b/patcher/location_types/event.py
@@ -11,6 +11,9 @@ class EventLocation:
     Most commonly, these take the form of NPCs giving Link an item during dialog.
     """
 
+    # Class variable that tracks open BMG files. This is done for performance reasons; a single BMG
+    # file can contain many item locations, and continously opening the same BMG file over and over
+    # again causes slowdowns.
     _filename_to_bmg_mapping: dict[bmg.BMG, str] = {}
 
     def __init__(self, instruction_index: int, file_path: str, *args, **kwargs):

--- a/patcher/location_types/event.py
+++ b/patcher/location_types/event.py
@@ -1,0 +1,32 @@
+import struct
+
+from ndspy import bmg
+
+from patcher import settings
+
+
+class EventLocation:
+    """These locations represent items given to the player by game events.
+
+    Most commonly, these take the form of NPCs giving Link an item during dialog.
+    """
+
+    _filename_to_bmg_mapping: dict[bmg.BMG, str] = {}
+
+    def __init__(self, instruction_index: int, file_path: str, *args, **kwargs):
+        self.instruction_index = instruction_index
+        self.file_path = file_path
+        self.bmg_file = bmg.BMG(settings.ROM.getFileByName(self.file_path))
+        EventLocation._filename_to_bmg_mapping[self.bmg_file] = self.file_path
+
+    def set_location(self, value: int):
+        self.bmg_file.instructions[self.instruction_index] = (
+            self.bmg_file.instructions[self.instruction_index][:4]
+            + struct.pack("<B", value)
+            + self.bmg_file.instructions[self.instruction_index][5:]
+        )
+
+    @classmethod
+    def save_all(cls):
+        for bmg_file, filename in EventLocation._filename_to_bmg_mapping.items():
+            settings.ROM.setFileByName(filename, bmg_file.save())

--- a/patcher/location_types/island_shop.py
+++ b/patcher/location_types/island_shop.py
@@ -1,0 +1,201 @@
+from ndspy import code
+
+from patcher import settings
+
+GD_MODELS = {
+    0x00: None,
+    0x01: "key",
+    0x02: "rupee_g",
+    0x03: "swA",
+    0x04: "shA",
+    0x05: "",  # TODO: what is this?
+    0x06: "gd_force_y",  # TODO: find force gem model
+    0x07: "bomb",
+    0x08: "bow",
+    0x09: "rupee_g",
+    0x0A: "heart_utu",
+    0x0B: "",  # TODO: what is this?
+    0x0C: "boomerang",
+    0x0D: "scp",
+    0x0E: "bombchu",
+    0x0F: "bosskey",
+    0x10: "rev_bin",
+    0x11: "",  # TODO: what is this?
+    0x12: "",  # TODO: what is this?
+    0x13: "mapSea",
+    0x14: "mapSea",
+    0x15: "mapSea",
+    0x16: "mapSea",
+    0x17: "",  # TODO: what is this?
+    0x18: "rupee_b",
+    0x19: "rupee_r",
+    0x1A: "rupee_r",
+    0x1B: "rupee_go",
+    0x1C: "gd_force_y",  # NOTE: Used in multiplayer mode only
+    0x1D: "gd_force_r",  # NOTE: Used in multiplayer mode only
+    0x1E: "gd_force_b",  # NOTE: Used in multiplayer mode only
+    0x1F: "ham",
+    0x20: "rope",
+    0x21: "cstl_c",
+    0x22: "cstl_s",
+    0x23: "cstl_t",
+    0x24: "fp",
+    0x25: "ship",  # TODO: ship or ship02?
+    0x26: "key_su",
+    0x27: "",  # TODO: what is this?
+    0x28: "arrowpodL",  # TODO: arrowpod or arrowpodL?
+    0x29: "bmbagL",  # TODO: bmbag or bmbagL or bmbagM?
+    0x2A: "bcbagL",  # TODO: bcbag or bcbagL or bcbagM?
+    0x2B: "",  # TODO: what is this?
+    0x2C: "key_ki",
+    0x2D: "minaP",
+    0x2E: "minaY",
+    0x2F: "minaC",
+    0x30: "sango",
+    0x31: "perlA",
+    0x32: "perlB",
+    0x33: "uroko",
+    0x34: "mineral",
+    0x35: "crown",
+    0x36: "wing",
+    0x37: "ring",
+    0x38: "key_gh",
+    0x39: "tic_tada",
+    0x3A: "tic_ohome",
+    0x3B: "tic_rare",
+    0x3C: "neckl",
+    0x3D: "slvarm",
+    0x3E: "",  # TODO: find id for hero"s new clothes
+    0x3F: "telescope",
+    0x40: "notebook",
+    0x41: "letter",
+    0x42: "card",
+    0x43: "marron",
+    0x44: "",  # TODO: what is this?
+    0x45: "",  # TODO: what is this?
+    0x46: "",  # TODO: what is this?
+    0x47: "",  # TODO: what is this?
+    0x48: "",  # TODO: what is this?
+    0x49: "",  # TODO: what is this?
+    0x4A: "",  # TODO: what is this?
+    0x4B: "mapTakara",
+    0x4C: "mapTakara",
+    0x4D: "mapTakara",
+    0x4E: "mapTakara",
+    0x4F: "mapTakara",
+    0x50: "mapTakara",
+    0x51: "mapTakara",
+    0x52: "mapTakara",
+    0x53: "mapTakara",
+    0x54: "mapTakara",
+    0x55: "mapTakara",
+    0x56: "mapTakara",
+    0x57: "mapTakara",
+    0x58: "mapTakara",
+    0x59: "mapTakara",
+    0x5A: "mapTakara",
+    0x5B: "mapTakara",
+    0x5C: "mapTakara",
+    0x5D: "mapTakara",
+    0x5E: "mapTakara",
+    0x5F: "mapTakara",
+    0x60: "mapTakara",
+    0x61: "mapTakara",
+    0x62: "mapTakara",
+    0x63: "mapTakara",
+    0x64: "mapTakara",
+    0x65: "mapTakara",
+    0x66: "mapTakara",
+    0x67: "mapTakara",
+    0x68: "mapTakara",
+    0x69: "mapTakara",
+    0x6A: "mapTakara",
+    0x6B: "",  # TODO: what is this?
+    0x6C: "",  # TODO: what is this?
+    0x6D: "",  # TODO: what is this?
+    0x6E: "",  # TODO: what is this?
+    0x6F: "",  # TODO: what is this?
+    0x70: "",  # TODO: what is this?
+    0x71: "",
+    0x72: "hagaH",
+    0x73: "hagaK",
+    0x74: "hagaS",
+    0x75: "rev_bin",
+    0x76: "rev_binP",
+    0x77: "rev_binY",
+    0x78: "sand_m",
+    0x79: "ship",  # TODO: ship or ship02?
+    0x7A: "ship",  # TODO: ship or ship02?
+    0x7B: "ship",  # TODO: ship or ship02?
+    0x7C: "ship",  # TODO: ship or ship02?
+    0x7D: "",  # TODO: what to do for random treasure?
+    0x7E: "",  # TODO: what to do for random ship part?
+    0x7F: "",  # TODO: find warp tablet model
+    0x80: "",  # TODO: find bait model
+    0x81: "rupee_bb",
+    0x82: "rupee_bb",
+    0x83: "",  # TODO: what is this?
+    0x84: "",  # TODO: what is this?
+    0x85: "",  # TODO: what to do for random ship part?
+    0x86: "",  # TODO: what to do for random treasure?
+    0x87: "",  # TODO: what to do for random ship part?
+    # TODO: are there any more items?
+}
+
+
+class IslandShopLocation:
+    """These locations represent items that can be purchased at island shops."""
+
+    _overlay_table: dict[int, code.Overlay] = {}
+
+    def __init__(self, overlay_number: int, item_id_index: int):
+        self.overlay_number = overlay_number
+        self.item_id_index = item_id_index
+
+    def set_location(self, new_item_id: int):
+        # Load arm9.bin and overlay table
+        arm9_executable = bytearray(
+            code.MainCodeFile(settings.ROM.arm9, 0x02000000).save(compress=False)
+        )
+        overlay_table = settings.ROM.loadArm9Overlays()
+
+        # Get current values of the items we're about to change
+        original_item_id: int = overlay_table[self.overlay_number].data[self.item_id_index]
+        original_model_name = f"gd_{GD_MODELS[original_item_id]}"
+
+        # Set the item id to the new one. This changes the "internal" item representation,
+        # but not the 3D model that is displayed prior to purchasing the item
+        overlay_table[self.overlay_number].data[self.item_id_index] = new_item_id
+
+        # The name of the NSBMD/NSBTX model we're changing to
+        new_model_name = f"gd_{GD_MODELS[new_item_id]}"
+
+        offset = arm9_executable.index(f"Player/get/{original_model_name}.nsbmd".encode("ascii"))
+        new_data = bytearray(f"Player/get/{new_model_name}.nsbmd".encode("ascii"))
+        arm9_executable = (
+            arm9_executable[:offset] + new_data + arm9_executable[offset + len(new_data) :]
+        )
+
+        offset = arm9_executable.index(f"Player/get/{original_model_name}.nsbtx".encode("ascii"))
+        new_data = bytearray(f"Player/get/{new_model_name}.nsbtx".encode("ascii"))
+        arm9_executable = (
+            arm9_executable[:offset] + new_data + arm9_executable[offset + len(new_data) :]
+        )
+
+        offset = overlay_table[self.overlay_number].data.index(original_model_name.encode("ascii"))
+        new_data = bytearray(new_model_name.encode("ascii"))
+        overlay_table[self.overlay_number].data = (
+            overlay_table[self.overlay_number].data[:offset]
+            + new_data
+            + overlay_table[self.overlay_number].data[offset + len(new_data) :]
+        )
+
+        settings.ROM.files[overlay_table[self.overlay_number].fileID] = overlay_table[
+            self.overlay_number
+        ].save(compress=True)
+        settings.ROM.arm9OverlayTable = code.saveOverlayTable(overlay_table)
+        settings.ROM.arm9 = arm9_executable
+
+    @classmethod
+    def save_all(cls):
+        pass

--- a/patcher/location_types/island_shop.py
+++ b/patcher/location_types/island_shop.py
@@ -171,24 +171,28 @@ class IslandShopLocation:
         new_model_name = f"gd_{GD_MODELS[new_item_id]}"
 
         offset = arm9_executable.index(f"Player/get/{original_model_name}.nsbmd".encode("ascii"))
-        new_data = bytearray(f"Player/get/{new_model_name}.nsbmd".encode("ascii"))
+        new_data = bytearray(f"Player/get/{new_model_name}.nsbmd".encode("ascii") + b"\x00")
         arm9_executable = (
             arm9_executable[:offset] + new_data + arm9_executable[offset + len(new_data) :]
         )
 
         offset = arm9_executable.index(f"Player/get/{original_model_name}.nsbtx".encode("ascii"))
-        new_data = bytearray(f"Player/get/{new_model_name}.nsbtx".encode("ascii"))
+        new_data = bytearray(f"Player/get/{new_model_name}.nsbtx".encode("ascii") + b"\x00")
         arm9_executable = (
             arm9_executable[:offset] + new_data + arm9_executable[offset + len(new_data) :]
         )
 
         offset = overlay_table[self.overlay_number].data.index(original_model_name.encode("ascii"))
-        new_data = bytearray(new_model_name.encode("ascii"))
+        new_data = bytearray(new_model_name.encode("ascii") + b"\x00")
         overlay_table[self.overlay_number].data = (
             overlay_table[self.overlay_number].data[:offset]
             + new_data
             + overlay_table[self.overlay_number].data[offset + len(new_data) :]
         )
+        # Pad remaining non-NULL chars to 0. If this isn't done and there are characters
+        # left from the previous item, the game will crash.
+        for i in range(offset + len(new_data), offset + 16):
+            overlay_table[self.overlay_number].data[i] = 0x0
 
         settings.ROM.files[overlay_table[self.overlay_number].fileID] = overlay_table[
             self.overlay_number

--- a/patcher/location_types/map_object.py
+++ b/patcher/location_types/map_object.py
@@ -1,0 +1,81 @@
+from collections import defaultdict
+from typing import Optional
+
+from ndspy import lz10, narc
+from zed.common import Game
+from zed.zmb import ZMB, MapObject
+
+from patcher import settings
+
+
+class MapObjectLocation:
+    """These locations represent items found "inside" a map object.
+
+    For example, items found in chests or that drop from rolling into a tree.
+    """
+
+    # maps filenames objects to ZMB objects
+    _zmb_filename_mapping: dict[str, ZMB] = {}
+
+    # maps NARC file objects to filenames
+    _narc_filename_mapping: dict[narc.NARC, str] = {}
+
+    # mapping between ZMB file names and their parent NARC files
+    _narc_to_zmb_mapping: dict[narc.NARC, list[str]] = defaultdict(list)
+
+    def __init__(self, child_index: int, file_path: str, *args, **kwargs):
+        self.child_index = child_index
+        self.file_path = file_path
+        self.zmb_file: Optional[ZMB] = None
+
+        # check if this zmb file is already open first
+        for filename, zmb_file in MapObjectLocation._zmb_filename_mapping.items():
+            if filename == self._zmb_filepath:
+                self.zmb_file = zmb_file
+
+        if self.zmb_file is None:
+            narc_file = narc.NARC(lz10.decompress(settings.ROM.getFileByName(self._narc_filepath)))
+            MapObjectLocation._narc_filename_mapping[narc_file] = self._narc_filepath
+            self.zmb_file = ZMB(
+                game=Game.PhantomHourglass, data=narc_file.getFileByName(self._zmb_filepath)
+            )
+            MapObjectLocation._narc_to_zmb_mapping[narc_file].append(self._zmb_filepath)
+            MapObjectLocation._zmb_filename_mapping[self._zmb_filepath] = self.zmb_file
+
+    def set_location(self, value: int):
+        assert self.zmb_file is not None
+        zmb_child_element: MapObject = self.zmb_file.mapObjects[self.child_index]
+        zmb_child_element.unk08 = value
+        MapObjectLocation._zmb_filename_mapping[self._zmb_filepath] = self.zmb_file
+
+    @property
+    def _narc_filepath(self):
+        """Return the filepath of the NARC archive (ending with '.bin' extension) containing this ZMB file."""
+        path: list[str] = []
+        for part in self.file_path.split("/"):
+            path.append(part)
+            if "." in part:
+                return "/".join(path)
+
+    @property
+    def _zmb_filepath(self):
+        """Return the filepath of the ZMB file within its parent NARC archive."""
+        index: int
+        part: str
+        for index, part in enumerate(self.file_path.split("/")):
+            if "." in part:
+                return "/".join(self.file_path.split("/")[index + 1 :])
+
+    @classmethod
+    def save_all(cls):
+        for narc_file, zmb_filenames in MapObjectLocation._narc_to_zmb_mapping.items():
+            for zmb_filename in zmb_filenames:
+                narc_file.setFileByName(
+                    zmb_filename,
+                    MapObjectLocation._zmb_filename_mapping[zmb_filename].save(
+                        game=Game.PhantomHourglass
+                    ),
+                )
+            settings.ROM.setFileByName(
+                MapObjectLocation._narc_filename_mapping[narc_file], lz10.compress(narc_file.save())
+            )

--- a/patcher/location_types/map_object.py
+++ b/patcher/location_types/map_object.py
@@ -14,6 +14,10 @@ class MapObjectLocation:
     For example, items found in chests or that drop from rolling into a tree.
     """
 
+    # Class variables that track open ZMB files. This is done for performance reasons; a single ZMB
+    # file can contain many item locations, and continously opening the same ZMB file over and over
+    # again causes slowdowns.
+
     # maps filenames objects to ZMB objects
     _zmb_filename_mapping: dict[str, ZMB] = {}
 

--- a/patcher/settings.py
+++ b/patcher/settings.py
@@ -1,0 +1,3 @@
+from ndspy.rom import NintendoDSRom
+
+ROM = NintendoDSRom.fromFile("base/out/out.nds")

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "ndspy==3.0.0",
+        "zed @ git+https://github.com/mikeoss/zed.git",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "ndspy==3.0.0",
-        "zed @ git+https://github.com/mikeoss/zed.git",
+        "zed @ git+https://github.com/phst-randomizer/zed.git",
     ],
 )


### PR DESCRIPTION
Brings in some code from `ph_utils` + some new code for setting item locations. Also includes an example script to demonstrate usage, mostly for documentation purposes.

Note, I've also switched to using `zed` over `zdspy` for ZMB editing, as I've found it to be much cleaner and easier to extend/modify. 