### PR TITLE
Relocate item shop model names

### DIFF
--- a/base/src/_island_shop_files.asm
+++ b/base/src/_island_shop_files.asm
@@ -1,0 +1,30 @@
+; Note - the .fill's are to ensure every entry is padded to 0x1D bytes. This is because the longest
+; file name in the Player/get directory is 29 (0x1D) characters long, and we want to be able to
+; change these to any given file name during randomization.
+;
+; TODO: I'm sure ARMIPS offers some feature that let's us do this more elegantly, but
+; for now manually specifying the .fill directives will do.
+shA_nsbmd:
+    .asciiz "Player/get/gd_shA.nsbmd"
+    .fill 6, 0
+shA_nsbtx:
+    .asciiz "Player/get/gd_shA.nsbtx"
+    .fill 6, 0
+minaP_nsbmd:
+    .asciiz "Player/get/gd_minaP.nsbmd"
+    .fill 4, 0
+minaP_nsbtx:
+    .asciiz "Player/get/gd_minaP.nsbtx"
+    .fill 4, 0
+arrowpod_nsbmd:
+    .asciiz "Player/get/gd_arrowpod.nsbmd"
+    .fill 1, 0
+arrowpod_nsbtx:
+    .asciiz "Player/get/gd_arrowpod.nsbtx"
+    .fill 1, 0
+bcbagM_nsbmd:
+    .asciiz "Player/get/gd_bcbagM.nsbmd"
+    .fill 3, 0
+bcbagM_nsbtx:
+    .asciiz "Player/get/gd_bcbagM.nsbtx"
+    .fill 3, 0

--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -8,7 +8,7 @@
         ; Area of unused space in arm9.bin; new code can be stored here
         .area 0x228, 0xFF
             .importobj "src/set_initial_flags.o"
-            .importobj "src/faster_boat.o"
+            // .importobj "src/faster_boat.o"
             .importobj "src/spawn_custom_freestanding_item.o"
 
             @init_flags:
@@ -16,11 +16,11 @@
                 bl set_initial_flags
                 pop r3, pc ; original instruction, do not change
 
-            @faster_boat:
-                push lr
-                strlt r0,[r4,0x78] ; original instruction, do not change
-                bl faster_boat
-                pop pc
+            // @faster_boat:
+            //     push lr
+            //     strlt r0,[r4,0x78] ; original instruction, do not change
+            //     bl faster_boat
+            //     pop pc
 
             @check_additional_items_tree_drop:
                 .include "_additional_tree_items.asm"
@@ -61,13 +61,13 @@
 .close
 
 
-.open "../overlay/overlay_0031.bin", 0x0211F5C0
-    .arm
-    .org 0x17420 + 0x0211F5C0 ;0x217bce0
-        .area 0x4
-            bl @faster_boat
-        .endarea
-.close
+// .open "../overlay/overlay_0031.bin", 0x0211F5C0
+//     .arm
+//     .org 0x17420 + 0x0211F5C0 ;0x217bce0
+//         .area 0x4
+//             bl @faster_boat
+//         .endarea
+// .close
 
 
 .open "../overlay/overlay_0037.bin", 0x0215b400

--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -26,6 +26,8 @@
                 .include "_additional_tree_items.asm"
                 ldr r0, [r4, 0x6c]
                 b 0x2162790
+
+            .include "_island_shop_files.asm"
         .pool
         .endarea
 .close
@@ -73,5 +75,43 @@
     .org 0x216278c
         .area 0x4, 0xff
             b @check_additional_items_tree_drop
+        .endarea
+.close
+
+.open "../overlay/overlay_0060.bin", 0x0217bce0
+    .arm
+    ; Relocate the shop item NSBMD/NSBTX filename strings so that
+    ; they can be changed without length overflow issues:
+    .org 0x21822b0
+        .area 0x4
+            .word org(shA_nsbmd)
+        .endarea
+    .org 0x2182304
+        .area 0x4
+            .word org(shA_nsbtx)
+        .endarea
+    .org 0x2182294
+        .area 0x4
+            .word org(arrowpod_nsbmd)
+        .endarea
+    .org 0x21822e8
+        .area 0x4
+            .word org(arrowpod_nsbtx)
+        .endarea
+    .org 0x21822a8
+        .area 0x4
+            .word org(minaP_nsbmd)
+        .endarea
+    .org 0x21822fc
+        .area 0x4
+            .word org(minaP_nsbtx)
+        .endarea
+    .org 0x2182298
+        .area 0x4
+            .word org(bcbagM_nsbmd)
+        .endarea
+    .org 0x21822ec
+        .area 0x4
+            .word org(bcbagM_nsbtx)
         .endarea
 .close


### PR DESCRIPTION
This relocates the "randomizable" shop item models to a free area in arm9.bin. Each entry is allocated enough space to fit the longest possible NSBMD filename, so we can randomize these to any item without causing an overflow if the new item's filename is longer than the old one's.