### PR TITLE
Optimize C code to decrease size of compiled binaries

### DIFF
--- a/base/src/set_initial_flags.c
+++ b/base/src/set_initial_flags.c
@@ -1,7 +1,7 @@
 #include "flags.h"
 #include <stdint.h>
 
-void set_flag(int addr, uint8_t bit) {
+__attribute__((always_inline)) static void set_flag(int addr, uint8_t bit) {
   *((uint8_t *)addr) |= bit;
 }
 

--- a/base/src/spawn_custom_freestanding_item.c
+++ b/base/src/spawn_custom_freestanding_item.c
@@ -2,14 +2,6 @@
 
 #define RUPY 0x52555059
 
-static uint16_t get_item_id() {
-  uint16_t *item_id_address;
-  // pull the base address of the NPCA entry's item_id off of the stack
-  asm volatile("ldr %0, [sp, #0x4]" : "=r"(item_id_address) :);
-  // return the item id
-  return item_id_address[0x10];
-}
-
 /**
  * @param param_1 - original function arg, don't modify
  * @param npc_type - 4 character string representing NPC type.
@@ -22,7 +14,13 @@ uint16_t spawn_custom_freestanding_item(void *param_1, uint32_t npc_type,
   uint16_t (*spawn_npc)(void *, uint32_t, void *, uint16_t *) =
       (void *)0x20C3FE8;
 
-  uint16_t item_id = get_item_id();
+  uint16_t *item_id_address;
+  // pull the base address of the NPCA entry's item_id off of the stack
+  asm volatile("ldr %0, [sp, #0x4]" : "=r"(item_id_address) :);
+
+  // get the item id
+  uint16_t item_id = item_id_address[0x10];
+
   // if item_id is 0x1, continue as the vanilla game does.
   if (item_id == 0x1) {
     return (*spawn_npc)(param_1, npc_type, param_3, param_4);


### PR DESCRIPTION
These optimizations cut down the sizes of some of the compiled C binaries. This won't resolve #31, but it should provide enough free space for #16 to at least build properly.