### PR TITLE
Randomize random treasure shop item

### DIFF
--- a/base/src/_island_shop_files.asm
+++ b/base/src/_island_shop_files.asm
@@ -28,3 +28,9 @@ bcbagM_nsbmd:
 bcbagM_nsbtx:
     .asciiz "Player/get/gd_bcbagM.nsbtx"
     .fill 3, 0
+random_treasure_nsbmd:
+    .asciiz "Player/get/gd_sango.nsbmd"
+    .fill 4, 0
+random_treasure_nsbtx:
+    .asciiz "Player/get/gd_sango.nsbtx"
+    .fill 4, 0

--- a/base/src/fixed_random_treasure_in_shop.c
+++ b/base/src/fixed_random_treasure_in_shop.c
@@ -1,0 +1,10 @@
+#include <stdint.h>
+
+__attribute__((target("thumb"))) void
+fixed_random_treasure_in_shop(char *stack_ptr, char *nsbmd_file,
+                              char *nsbtx_file) {
+  for (int i = 0; i < 30; i++) {
+    stack_ptr[i + 0x1C] = nsbtx_file[i];
+    stack_ptr[i + 0x44] = nsbmd_file[i];
+  }
+}

--- a/patcher/location_types/island_shop.py
+++ b/patcher/location_types/island_shop.py
@@ -182,17 +182,24 @@ class IslandShopLocation:
             arm9_executable[:offset] + new_data + arm9_executable[offset + len(new_data) :]
         )
 
-        offset = overlay_table[self.overlay_number].data.index(original_model_name.encode("ascii"))
-        new_data = bytearray(new_model_name.encode("ascii") + b"\x00")
-        overlay_table[self.overlay_number].data = (
-            overlay_table[self.overlay_number].data[:offset]
-            + new_data
-            + overlay_table[self.overlay_number].data[offset + len(new_data) :]
-        )
-        # Pad remaining non-NULL chars to 0. If this isn't done and there are characters
-        # left from the previous item, the game will crash.
-        for i in range(offset + len(new_data), offset + 16):
-            overlay_table[self.overlay_number].data[i] = 0x0
+        try:
+            offset = overlay_table[self.overlay_number].data.index(
+                original_model_name.encode("ascii")
+            )
+            new_data = bytearray(new_model_name.encode("ascii") + b"\x00")
+            overlay_table[self.overlay_number].data = (
+                overlay_table[self.overlay_number].data[:offset]
+                + new_data
+                + overlay_table[self.overlay_number].data[offset + len(new_data) :]
+            )
+            # Pad remaining non-NULL chars to 0. If this isn't done and there are characters
+            # left from the previous item, the game will crash.
+            for i in range(offset + len(new_data), offset + 16):
+                overlay_table[self.overlay_number].data[i] = 0x0
+        except ValueError:
+            # Random treasure items (which should be fixed to Pink Coral in our hacked base rom)
+            # are an exception and do not require this step.
+            assert original_item_id == 0x30
 
         settings.ROM.files[overlay_table[self.overlay_number].fileID] = overlay_table[
             self.overlay_number

--- a/patcher/locations.py
+++ b/patcher/locations.py
@@ -33,6 +33,7 @@ LOCATIONS: dict[str, DigSpotLocation | EventLocation | IslandShopLocation | MapO
     ),
     "mercay_island_shop_shield": IslandShopLocation(31, 0x217ECB4 - 0x217BCE0),
     "mercay_island_shop_power_gem": IslandShopLocation(31, 0x217EC68 - 0x217BCE0),
+    "mercay_island_shop_random_treasure": IslandShopLocation(31, 0x217EC34 - 0x217BCE0),
     "mercay_island_oshus_house_dig_spot": DigSpotLocation(
         5, "Map/isle_main/map00.bin/zmb/isle_main_00.zmb"
     ),


### PR DESCRIPTION
This PR
- [X] Patches out the NDS-clock-based randomization for the random treasure that is purchasable in the island shops
	- It's patched to always be the Pink Coral, no matter what the NDS clock date is. Of course, this item can then be changed as usual with the patcher.
- [x] Makes that item randomizable
	- The random treasure item handles the spawning of its NSBMD model very differently than the "regular" shop items. 