### PR TITLE
Progressive sword

### DIFF
--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -7,14 +7,17 @@
     .org 0x54180 + 0x2004000
         ; Area of unused space in arm9.bin; new code can be stored here
         .area 0x301, 0xFF
+            .arm
             .importobj "src/faster_boat.o"
             .importobj "src/fixed_random_treasure_in_shop.o"
+            .importobj "src/progressive_sword_check.o"
             .include "_island_shop_files.asm"
         .endarea
 
     .org 0x54894 + 0x2004000
         ; Area of unused space in arm9.bin; new code can be stored here
         .area 0x228, 0xFF
+            .arm
             .importobj "src/set_initial_flags.o"
             .importobj "src/spawn_custom_freestanding_item.o"
 
@@ -56,6 +59,18 @@
         .area 0x4
             b @init_flags
         .endarea
+
+    .thumb
+    .org 0x20ade1c
+        ; Overwrite code that gives the player the oshus sword to be progressive
+        .area 0xC, 0x00
+            ; Save scratch registers, since gcc doesn't do it
+            push r0, r1, r2, r3
+            bl progressive_sword_check
+            pop r0, r1, r2, r3
+        .endarea
+
+
 .close
 
 

--- a/base/src/progressive_sword_check.c
+++ b/base/src/progressive_sword_check.c
@@ -1,0 +1,29 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+#define OSHUS_SWORD_FLAG_OFFSET (0x128)
+#define OSHUS_SWORD_FLAG_BIT (0x1)
+#define PHANTOM_SWORD_FLAG_OFFSET (0x12C)
+#define PHANTOM_SWORD_FLAG_BIT (0x20)
+
+__attribute__((target("thumb"))) void
+progressive_sword_check(const uint32_t base_address) {
+  // Address of oshus sword flag
+  uint8_t *oshus_sword = (uint8_t *)(base_address + OSHUS_SWORD_FLAG_OFFSET);
+
+  // Address of phantom sword flag
+  uint8_t *phantom_sword =
+      (uint8_t *)(base_address + PHANTOM_SWORD_FLAG_OFFSET);
+
+  // Check if player has the oshus sword
+  bool has_oshus_sword =
+      (*oshus_sword & OSHUS_SWORD_FLAG_BIT) == OSHUS_SWORD_FLAG_BIT;
+
+  // If the player has the oshus sword already, give them the phantom sword.
+  // Otherwise, give them the oshus sword
+  if (has_oshus_sword) {
+    *phantom_sword |= PHANTOM_SWORD_FLAG_BIT;
+  } else {
+    *oshus_sword |= OSHUS_SWORD_FLAG_BIT;
+  }
+}


### PR DESCRIPTION
Closes #18 

With these changes, the oshus sword item will check if the player already has it, and if so give them the phantom sword instead.