### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip --user
 
       - name: Run tox
         run: |
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip --user
 
       - name: Fetch PH rom
         run: |
@@ -170,7 +170,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip --user
 
       - name: Fetch PH rom
         run: |


### PR DESCRIPTION
The CI step that runs on Windows is currently failing because a new release of pip occurred, and it's attempting to run the update command with elevated permissions. 