### PR TITLE
Fix shuffler/patcher imports

### DIFF
--- a/patcher/patcher.py
+++ b/patcher/patcher.py
@@ -5,6 +5,20 @@ from ndspy import rom
 from util import load_aux_data, load_rom, patch_rom
 
 
+def patcher(
+    aux_data_directory: str, input_rom_path: str, output_rom_path: str | None
+) -> rom.NintendoDSRom:
+    input_rom = load_rom(Path(input_rom_path))
+    new_aux_data = load_aux_data(Path(aux_data_directory))
+    patched_rom = patch_rom(new_aux_data, input_rom)
+
+    if output_rom_path is not None:
+        # Save the ROM to disk
+        patched_rom.saveToFile(output_rom_path)
+
+    return patched_rom
+
+
 @click.command()
 @click.option(
     "-a",
@@ -23,19 +37,9 @@ from util import load_aux_data, load_rom, patch_rom
 @click.option(
     "-o", "--output-rom-path", default=None, type=str, help="Path to save patched ROM to."
 )
-def patcher(
-    aux_data_directory: str, input_rom_path: str, output_rom_path: str | None
-) -> rom.NintendoDSRom:
-    input_rom = load_rom(Path(input_rom_path))
-    new_aux_data = load_aux_data(Path(aux_data_directory))
-    patched_rom = patch_rom(new_aux_data, input_rom)
-
-    if output_rom_path is not None:
-        # Save the ROM to disk
-        patched_rom.saveToFile(output_rom_path)
-
-    return patched_rom
+def patcher_cli(aux_data_directory: str, input_rom_path: str, output_rom_path: str | None):
+    return patcher(aux_data_directory, input_rom_path, output_rom_path)
 
 
 if __name__ == "__main__":
-    patcher()
+    patcher_cli()

--- a/patcher/patcher.py
+++ b/patcher/patcher.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import click
 from ndspy import rom
-from util import load_aux_data, load_rom, patch_rom
+
+from .util import load_aux_data, load_rom, patch_rom
 
 
 def patcher(

--- a/patcher/util.py
+++ b/patcher/util.py
@@ -2,9 +2,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from items import ITEMS
-from location_types import EventLocation, IslandShopLocation, Location, MapObjectLocation
 from ndspy import rom
+
+from .items import ITEMS
+from .location_types import EventLocation, IslandShopLocation, Location, MapObjectLocation
 
 
 def load_rom(file: Path):

--- a/shuffler/shuffler.py
+++ b/shuffler/shuffler.py
@@ -1,12 +1,13 @@
 import json
 import logging
-from parser import Descriptor, Edge, Node, parse
 from pathlib import Path
 from random import randint
 import sys
 from typing import Any
 
 import click
+
+from .parser import Descriptor, Edge, Node, parse
 
 logging.basicConfig(level=logging.INFO)
 

--- a/shuffler/shuffler.py
+++ b/shuffler/shuffler.py
@@ -188,22 +188,6 @@ def traverse_graph(
     return False
 
 
-@click.command()
-@click.option(
-    "-a",
-    "--aux-data-directory",
-    required=True,
-    type=click.Path(exists=True),
-    help="File path to directory that contains aux data.",
-)
-@click.option("-l", "--logic-directory", required=True, type=click.Path(exists=True))
-@click.option(
-    "-o",
-    "--output",
-    default=None,
-    type=click.Path(exists=False, dir_okay=True, file_okay=False),
-    help="Path to save randomized aux data to. Use -- to output to stdout.",
-)
 def shuffler(aux_data_directory: str, logic_directory: str, output: str | None):
     global nodes, edges, visited_nodes, inventory
 
@@ -244,5 +228,25 @@ def shuffler(aux_data_directory: str, logic_directory: str, output: str | None):
     return areas
 
 
+@click.command()
+@click.option(
+    "-a",
+    "--aux-data-directory",
+    required=True,
+    type=click.Path(exists=True),
+    help="File path to directory that contains aux data.",
+)
+@click.option("-l", "--logic-directory", required=True, type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    default=None,
+    type=click.Path(exists=False, dir_okay=True, file_okay=False),
+    help="Path to save randomized aux data to. Use -- to output to stdout.",
+)
+def shuffler_cli(aux_data_directory: str, logic_directory: str, output: str | None):
+    return shuffler(aux_data_directory, logic_directory, output)
+
+
 if __name__ == "__main__":
-    shuffler()
+    shuffler_cli()


### PR DESCRIPTION
My original intention with the `shuffler()` and `patcher()` functions was to allow them to be importable and used as regular Python functions, while also being CLIs for testing. I didn't realized the `click` decorators override the function signatures though, so those functions weren't actually importable. This PR fixes this so they can be used in both modes.