### PR TITLE
Fix incorrect shop model for quiver upgrade

### DIFF
--- a/base/src/_island_shop_files.asm
+++ b/base/src/_island_shop_files.asm
@@ -17,10 +17,10 @@ minaP_nsbtx:
     .asciiz "Player/get/gd_minaP.nsbtx"
     .fill 4, 0
 arrowpod_nsbmd:
-    .asciiz "Player/get/gd_arrowpod.nsbmd"
+    .asciiz "Player/get/gd_arrowpodL.nsbmd"
     .fill 1, 0
 arrowpod_nsbtx:
-    .asciiz "Player/get/gd_arrowpod.nsbtx"
+    .asciiz "Player/get/gd_arrowpodL.nsbtx"
     .fill 1, 0
 bcbagM_nsbmd:
     .asciiz "Player/get/gd_bcbagM.nsbmd"


### PR DESCRIPTION
This was resulting in a crash whenever the quiver upgrade item was placed in a shop.