### PR TITLE
Add PyInstaller spec file that bundles logic/aux data

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -331,7 +331,7 @@ jobs:
         run: pip install -U pyinstaller
 
       - name: Build randomizer executable
-        run: pyinstaller --onefile randomizer.py
+        run: pyinstaller randomizer.spec
 
       - name: Download base rom patch from previous workflow
         uses: actions/download-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/randomizer.py
+++ b/randomizer.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 from tempfile import TemporaryDirectory
 
 import click
@@ -9,6 +10,16 @@ from shuffler import shuffle
 # TODO: this is an example script for how to call the patcher/shuffler.
 # At some point this will be fleshed out into a full CLI (and eventually
 # GUI) to run the full randomizer.
+
+
+def is_frozen():
+    """
+    Whether or not the app is being executed as part of a script or a frozen executable.
+
+    This can be used to determine if the app is running as a regular python script,
+    or if it's a bundled PyInstaller executable.
+    """
+    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 
 
 @click.command()
@@ -27,8 +38,12 @@ from shuffler import shuffle
     help="Path to save randomized ROM to.",
 )
 def randomizer(input_rom_path: str, output_rom_path: str):
-    aux_data_directory = str(Path(__file__).parent / "shuffler" / "auxiliary")
-    logic_directory = str(Path(__file__).parent / "shuffler" / "logic")
+    if is_frozen():
+        aux_data_directory = str(Path(sys._MEIPASS) / "auxiliary")  # type: ignore
+        logic_directory = str(Path(sys._MEIPASS) / "logic")  # type: ignore
+    else:
+        aux_data_directory = str(Path(__file__).parent / "shuffler" / "auxiliary")
+        logic_directory = str(Path(__file__).parent / "shuffler" / "logic")
 
     with TemporaryDirectory() as tmp_dir:
         # Run the shuffler

--- a/randomizer.spec
+++ b/randomizer.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['randomizer.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        # Bundle logic + aux data files inside executable
+        ('shuffler/auxiliary/', 'auxiliary'),
+        ('shuffler/logic/', 'logic'),
+        # TODO: bundle base patches as well
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='randomizer',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
This makes it so that the bundled CLI executable can actually find the logic and aux data, i.e. it will actually work now (relatively at least, it will still go into an infinite loop since there's no way to get bombs in the aux data yet)

Closes #77 