### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -361,8 +361,8 @@ jobs:
       - check-logic
       - check-aux-data
       - test-desmume
-    # Only create a release if a tag was pushed to main
-    if: "startsWith(github.ref, 'refs/tags/') && github.ref == 'refs/heads/main'"
+    # Only create a release if a tag was pushed
+    if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The current conditions for allowing a release don't work because tags aren't associated with branches. Tags are completely separate from the notion of branches in git, so that if statement doesn't make any sense.