### PR TITLE
Extend shuffler + randomizer CLI to support seeds

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -37,7 +37,8 @@ def is_frozen():
     required=True,
     help="Path to save randomized ROM to.",
 )
-def randomizer(input_rom_path: str, output_rom_path: str):
+@click.option("-s", "--seed", type=str, required=False, help="Seed for the randomizer.")
+def randomizer(input_rom_path: str, output_rom_path: str, seed: str | None):
     if is_frozen():
         aux_data_directory = str(Path(sys._MEIPASS) / "auxiliary")  # type: ignore
         logic_directory = str(Path(sys._MEIPASS) / "logic")  # type: ignore
@@ -47,7 +48,7 @@ def randomizer(input_rom_path: str, output_rom_path: str):
 
     with TemporaryDirectory() as tmp_dir:
         # Run the shuffler
-        shuffle(aux_data_directory, logic_directory, tmp_dir)
+        shuffle(seed, aux_data_directory, logic_directory, tmp_dir)
         # Run the patcher
         patch(tmp_dir, input_rom_path, output_rom_path)
 

--- a/shuffler/main.py
+++ b/shuffler/main.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from pathlib import Path
-from random import randint
+import random
 import sys
 from typing import Any
 
@@ -57,7 +57,7 @@ def randomize_aux_data(aux_data_directory: Path):
         for room in area["rooms"]:
             if "chests" in room:
                 for chest in room["chests"]:
-                    chest["contents"] = chest_items.pop(randint(0, len(chest_items) - 1))
+                    chest["contents"] = chest_items.pop(random.randint(0, len(chest_items) - 1))
     return areas
 
 
@@ -189,8 +189,11 @@ def traverse_graph(
     return False
 
 
-def shuffle(aux_data_directory: str, logic_directory: str, output: str | None = None):
+def shuffle(seed: str | None, aux_data_directory: str, logic_directory: str, output: str | None = None):
     global nodes, edges, visited_nodes, inventory
+
+    if seed is not None:
+        random.seed(seed)
 
     nodes, edges = parse(Path(logic_directory))
 
@@ -245,8 +248,11 @@ def shuffle(aux_data_directory: str, logic_directory: str, output: str | None = 
     type=click.Path(exists=False, dir_okay=True, file_okay=False),
     help="Path to save randomized aux data to. Use -- to output to stdout.",
 )
-def shuffler_cli(aux_data_directory: str, logic_directory: str, output: str | None):
-    return shuffle(aux_data_directory, logic_directory, output)
+@click.option("-s", "--seed", type=str, required=False, help="Seed for the RNG.")
+def shuffler_cli(
+    aux_data_directory: str, logic_directory: str, output: str | None, seed: str | None
+):
+    return shuffle(seed, aux_data_directory, logic_directory, output)
 
 
 if __name__ == "__main__":

--- a/shuffler/main.py
+++ b/shuffler/main.py
@@ -189,7 +189,21 @@ def traverse_graph(
     return False
 
 
-def shuffle(seed: str | None, aux_data_directory: str, logic_directory: str, output: str | None = None):
+def shuffle(
+    seed: str | None, aux_data_directory: str, logic_directory: str, output: str | None = None
+) -> list[dict]:
+    """
+    Given aux data and logic, shuffles the aux data and returns it.
+
+    Params:
+        seed: Some string that will be hashed and used as a seed for the RNG.
+        aux_data_directory: Path to a directory containing initial, unrandomized aux data
+        logic_directory: Path to a directory containing graph logic files
+        output: Optional directory to output randomized aux data to.
+
+    Returns:
+        Randomized aux data.
+    """
     global nodes, edges, visited_nodes, inventory
 
     if seed is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+import json
 import os
 from pathlib import Path
 import shutil
@@ -184,3 +185,35 @@ def dig_spot_test_emu(tmp_path: Path, desmume_emulator: DesmumeEmulator, request
     desmume_emulator.open_rom(rom_path)
 
     return desmume_emulator
+
+
+@pytest.fixture
+def aux_data_directory(tmp_path: Path):
+    dest = tmp_path / "auxiliary"
+    shutil.copytree(Path(__file__).parent.parent / "shuffler" / "auxiliary", dest)
+
+    # Add a new chest to Mercay aux data containing bombs, so that a beatable seed can actually
+    # be generated.
+    # TODO: Remove this once there's enough aux data completed to generate a beatable seed.
+    with open(dest / "SW Sea" / "Mercay Island" / "Mercay.json", "r") as fd:
+        mercay_json = json.load(fd)
+    mercay_json["rooms"][0]["chests"].append(
+        {
+            "name": "test",
+            "type": "chest",
+            "contents": "bombs",
+            "bmg_file_path": "TODO",
+            "bmg_instruction_index": -1,
+        }
+    )
+    with open(dest / "SW Sea" / "Mercay Island" / "Mercay.json", "w") as fd:
+        fd.write(json.dumps(mercay_json))
+
+    return str(dest)
+
+
+@pytest.fixture
+def logic_directory(tmp_path: Path):
+    dest = tmp_path / "logic"
+    shutil.copytree(Path(__file__).parent.parent / "shuffler" / "logic", dest)
+    return str(dest)

--- a/tests/test_shuffler.py
+++ b/tests/test_shuffler.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import pytest
+
+from shuffler import shuffle
 from shuffler._parser import Node, NodeContents, parse
 
 
@@ -66,3 +69,12 @@ def test_parser(tmp_path: Path):
     assert nodes == expected_nodes
 
     # TODO: test edges once edge parsing is implemented
+
+
+@pytest.mark.parametrize("seed", ["test", "another_test", "ANOTHER_TEST!!", "this_is_a_real_seed"])
+def test_seeds(seed: str, aux_data_directory: str, logic_directory: str):
+    """Test that running the shuffler with the same seed multiple times produces identical aux data."""
+    first = shuffle(seed, aux_data_directory, logic_directory)
+    second = shuffle(seed, aux_data_directory, logic_directory)
+    third = shuffle(seed, aux_data_directory, logic_directory)
+    assert first == second == third


### PR DESCRIPTION
This lets the user specify a seed when running the randomizer. Two or more randomizer runs with the same seed will generate identical ROMs. I also wrote [a short test](https://github.com/phst-randomizer/ph-randomizer/pull/80/commits/8d6ba3872f94aabc3e0139f96b205f67ba9730fc#diff-98c05bb95f83319d5c321653f05648ee3f654ed7a6a9a01d1ed5cc87417f4ddeR49-R55) that verifies that this behaves as intended.

For now, the user can just specify some arbitrary string as the seed. In the future, definitely by the time we have a GUI, we can make this a bit more user friendly and do the auto-generated seed "phrases" that other randomizers like WW and TP have.