### PR TITLE
Create logic to aux data tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ data/
 overlay/
 *.bin
 *.nds
+
+# PyCharm
+.idea/

--- a/shuffler/_parser.py
+++ b/shuffler/_parser.py
@@ -151,6 +151,11 @@ def parse_area(lines: list[str]):
         area_name = line.split(" ")[1].rstrip(":")
         logging.debug(f"area {area_name}")
         parse_rooms(area_name, lines)
+    return nodes
+
+
+def clear_nodes():
+    nodes.clear()
 
 
 def parse(directory: Path):

--- a/shuffler/auxiliary/Dungeons/Courage Temple/CourageTemple.wip-json
+++ b/shuffler/auxiliary/Dungeons/Courage Temple/CourageTemple.wip-json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "CourageTemple",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "AfterSpikeTraps",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BombableWallChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "PolsKey",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        },
+        {
+          "name": "ToB1Arena",
+          "link": ""
+        },
+        {
+          "name": "ToB1PolsVoice",
+          "link": ""
+        },
+        {
+          "name": "ToF2ElectricMaze",
+          "link": ""
+        },
+        {
+          "name": "ToB1InvisibleMaze",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Courage Temple/CraykBossRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/Courage Temple/CraykBossRoom.wip-json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "CraykBossRoom",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Sand",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "SpiritOfCourage",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HeartContainer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToDungeon",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Fire Temple/BlaazBossRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/Fire Temple/BlaazBossRoom.wip-json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "BlaazBossRoom",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "SpiritOfPower",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HeartContainer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToDungeon",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Fire Temple/FireTemple.wip-json
+++ b/shuffler/auxiliary/Dungeons/Fire Temple/FireTemple.wip-json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "FireTemple",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "KeesesSmallKey",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "ChestNearLavaPit",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Ghost Ship/GhostShip.wip-json
+++ b/shuffler/auxiliary/Dungeons/Ghost Ship/GhostShip.wip-json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GhostShip",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "ToB1",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    },
+    {
+      "chests": [
+        {
+          "name": "AfterJump",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [],
+      "name": "B1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Goron Temple/DongorongoBossRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/Goron Temple/DongorongoBossRoom.wip-json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GoronTemple",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Sand",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HeartContainer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToDungeon",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Goron Temple/GoronTemple.wip-json
+++ b/shuffler/auxiliary/Dungeons/Goron Temple/GoronTemple.wip-json
@@ -1,0 +1,165 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GoronTemple",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "AfterSwitch",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "EyeShot",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Entrance",
+          "link": ""
+        },
+        {
+          "name": "RightBombableWall",
+          "link": ""
+        },
+        {
+          "name": "LeftBombableWall",
+          "link": ""
+        },
+        {
+          "name": "ToB1Shortcut",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "LeftDoor",
+          "link": ""
+        },
+        {
+          "name": "RightDoor",
+          "link": ""
+        },
+        {
+          "name": "ToB1",
+          "link": ""
+        }
+      ],
+      "name": "BombableF1"
+    },
+    {
+      "chests": [
+        {
+          "name": "BigChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "EyeSlugSlayer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToBombableF1",
+          "link": ""
+        },
+        {
+          "name": "ToF1Shortcut",
+          "link": ""
+        },
+        {
+          "name": "ToB2",
+          "link": ""
+        }
+      ],
+      "name": "B1"
+    },
+    {
+      "chests": [
+        {
+          "name": "EyeSlugSlayer",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BossKey",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB1",
+          "link": ""
+        },
+        {
+          "name": "ToB3",
+          "link": ""
+        },
+        {
+          "name": "ToB3BossKey",
+          "link": ""
+        }
+      ],
+      "name": "B2"
+    },
+    {
+      "chests": [
+        {
+          "name": "MiniblinSlayer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB2Right",
+          "link": ""
+        },
+        {
+          "name": "ToB4",
+          "link": ""
+        }
+      ],
+      "name": "B3"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "ToB3",
+          "link": ""
+        },
+        {
+          "name": "ToBoss",
+          "link": ""
+        }
+      ],
+      "name": "B4"
+    },
+    {
+      "chests": [
+        {
+          "name": "Crimsonine",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToBoss",
+          "link": ""
+        }
+      ],
+      "name": "CrimsonineRoom"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Ice Temple/GleeokBossRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/Ice Temple/GleeokBossRoom.wip-json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GleeokBossRoom",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Sand",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HeartContainer",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToDungeon",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/Ice Temple/IceTemple.wip-json
+++ b/shuffler/auxiliary/Dungeons/Ice Temple/IceTemple.wip-json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "IceTemple",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB0.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB0.wip-json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "EmptyChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Map",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        },
+        {
+          "name": "ToB1",
+          "link": ""
+        }
+      ],
+      "name": "F1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB1.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB1.wip-json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Key",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Killer",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "EyeTarget",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToF1",
+          "link": ""
+        },
+        {
+          "name": "ToB2",
+          "link": ""
+        }
+      ],
+      "name": "B1"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB2.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB2.wip-json
@@ -1,0 +1,36 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Key",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Killer",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BombchuPath",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB1",
+          "link": ""
+        },
+        {
+          "name": "ToB3",
+          "link": ""
+        }
+      ],
+      "name": "B2"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB3.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB3.wip-json
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "TopLeft",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BottomRight",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "PhantomKey",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "EyeChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Killer",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BehindDoor",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToChartRoomShortcut",
+          "link": ""
+        },
+        {
+          "name": "ToChartRoom",
+          "link": ""
+        }
+      ],
+      "name": "B3"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB3ChartRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB3ChartRoom.wip-json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "NWChartChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB3Ledge",
+          "link": ""
+        },
+        {
+          "name": "ToB3Main",
+          "link": ""
+        },
+        {
+          "name": "ToB4",
+          "link": ""
+        }
+      ],
+      "name": "B3Chart"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB4.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB4.wip-json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "FreestandingKey",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "PhantomKiller",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "EyeKiller",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB3",
+          "link": ""
+        },
+        {
+          "name": "ToB5Shortcut",
+          "link": ""
+        },
+        {
+          "name": "ToB5",
+          "link": ""
+        }
+      ],
+      "name": "B4"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB5.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB5.wip-json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "AfterSwitch",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BigChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB4",
+          "link": ""
+        },
+        {
+          "name": "ToB6",
+          "link": ""
+        },
+        {
+          "name": "ToB4Shortcut",
+          "link": ""
+        },
+        {
+          "name": "ToB6",
+          "link": ""
+        }
+      ],
+      "name": "B5"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB6.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB6.wip-json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "EyeChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "PhantomKiller",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToB5",
+          "link": ""
+        },
+        {
+          "name": "Hourglass",
+          "link": ""
+        },
+        {
+          "name": "Triforce",
+          "link": ""
+        }
+      ],
+      "name": "B6"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB6SunMapRoom.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Dungeon/TempleOfTheOceanKingB6SunMapRoom.wip-json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKing",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [],
+      "name": "B3Chart"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Dungeons/ToTOK/Lobby/TempleOfTheOceanKingLobby.wip-json
+++ b/shuffler/auxiliary/Dungeons/ToTOK/Lobby/TempleOfTheOceanKingLobby.wip-json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../../aux-schema.json",
+  "name": "TempleOfTheOceanKingLobby",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Hourglass",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        },
+        {
+          "name": "Entrance",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/NE Sea/ManOfSmilesBoat/ManOfSmilesBoat.wip-json
+++ b/shuffler/auxiliary/NE Sea/ManOfSmilesBoat/ManOfSmilesBoat.wip-json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "ManOfSmilesBoat",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "NormalThing",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "MysteriousThing",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/NE Sea/MazeIsland/MazeIsland.wip-json
+++ b/shuffler/auxiliary/NE Sea/MazeIsland/MazeIsland.wip-json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "MazeIsland",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Lvl1",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Lvl2",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Lvl3",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HiddenChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/NW Sea/Bannan Island/Bannan.wip-json
+++ b/shuffler/auxiliary/NW Sea/Bannan Island/Bannan.wip-json
@@ -1,0 +1,57 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Bannan",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "IslandChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "WayfarerHouse",
+          "link": ""
+        }
+      ],
+      "name": "OutsideLeft"
+    },
+    {
+      "chests": [
+        {
+          "name": "CannonMiniGameBombBag",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "LeftIslandChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "RightIslandChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [],
+      "name": "OutsideRight"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "OutsideLeft",
+          "link": ""
+        },
+        {
+          "name": "OutsideRight",
+          "link": ""
+        }
+      ],
+      "name": "BannanGrotto"
+    }
+  ]
+}

--- a/shuffler/auxiliary/NW Sea/Isle of Gust/GustIsle.wip-json
+++ b/shuffler/auxiliary/NW Sea/Isle of Gust/GustIsle.wip-json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GustIsle",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "Grotto",
+          "link": ""
+        },
+        {
+          "name": "Cave",
+          "link": ""
+        }
+      ],
+      "name": "BeforeCave"
+    }
+  ]
+}

--- a/shuffler/auxiliary/NW Sea/Zauz Island/Zauz.wip-json
+++ b/shuffler/auxiliary/NW Sea/Zauz Island/Zauz.wip-json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Zauz",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Ship",
+          "link": ""
+        }
+      ],
+      "name": "Port"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SE Sea/Dee Ess Island/DSIsland.wip-json
+++ b/shuffler/auxiliary/SE Sea/Dee Ess Island/DSIsland.wip-json
@@ -1,0 +1,37 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "DeeEssIsland",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "BlowInTheMicrophone",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "GoronGame",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "HinoxSlayer",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "UndergroundGem",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SE Sea/Goron Island/Goron.wip-json
+++ b/shuffler/auxiliary/SE Sea/Goron Island/Goron.wip-json
@@ -1,0 +1,223 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "GoronIsland",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "LowerHouse",
+          "link": ""
+        },
+        {
+          "name": "ToNorth",
+          "link": ""
+        },
+        {
+          "name": "Shop",
+          "link": ""
+        },
+        {
+          "name": "LeftmostHouse",
+          "link": ""
+        },
+        {
+          "name": "RightmostHouse",
+          "link": ""
+        },
+        {
+          "name": "ToEast",
+          "link": ""
+        },
+        {
+          "name": "ToEastLedge",
+          "link": ""
+        }
+      ],
+      "name": "LowerLeft"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "NoRockGoronHouse"
+    },
+    {
+      "chests": [
+        {
+          "name": "BombchuBagUpgrade",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "RandomTreasure",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "GoronShop"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "OneRockSmallGoronHouse"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "ThreeRocksGoronHouse"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "ToWest",
+          "link": ""
+        },
+        {
+          "name": "ToWestLedge",
+          "link": ""
+        },
+        {
+          "name": "LeftmostHouse",
+          "link": ""
+        },
+        {
+          "name": "CoastHouse",
+          "link": ""
+        },
+        {
+          "name": "ChiefHouse",
+          "link": ""
+        },
+        {
+          "name": "ToNorth",
+          "link": ""
+        }
+      ],
+      "name": "LowerRight"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "OneRockBigGoronHouse"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "TwoRocksGoronHouse"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "GoronChiefHouse"
+    },
+    {
+      "chests": [
+        {
+          "name": "BombchuChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToSouth",
+          "link": ""
+        },
+        {
+          "name": "ToWestUpper",
+          "link": ""
+        },
+        {
+          "name": "ToWestLowest",
+          "link": ""
+        },
+        {
+          "name": "ToWestUppest",
+          "link": ""
+        },
+        {
+          "name": "ToWestLower",
+          "link": ""
+        }
+      ],
+      "name": "UpperRight"
+    },
+    {
+      "chests": [
+        {
+          "name": "MazeChest",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToEastLowest",
+          "link": ""
+        },
+        {
+          "name": "ToEastUppest",
+          "link": ""
+        },
+        {
+          "name": "ToEastLower",
+          "link": ""
+        },
+        {
+          "name": "ToEastUpper",
+          "link": ""
+        },
+        {
+          "name": "GoronTemple",
+          "link": ""
+        },
+        {
+          "name": "ToSouth",
+          "link": ""
+        }
+      ],
+      "name": "UpperLeft"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SE Sea/Harrow Island/Harrow.wip-json
+++ b/shuffler/auxiliary/SE Sea/Harrow Island/Harrow.wip-json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "HarrowIsland",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "TreasureMap",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SE Sea/HoHoBoat/HoHoBoat.wip-json
+++ b/shuffler/auxiliary/SE Sea/HoHoBoat/HoHoBoat.wip-json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Boat",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "TradingSequence",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SE Sea/Isle of Frost/FrostIsle.wip-json
+++ b/shuffler/auxiliary/SE Sea/Isle of Frost/FrostIsle.wip-json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "FrostIsle",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "LedgeChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "BigGreenRupee",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "SmartAnoukiHouse",
+          "link": ""
+        },
+        {
+          "name": "SensitiveAnoukiHouse",
+          "link": ""
+        },
+        {
+          "name": "ChiefHouse",
+          "link": ""
+        },
+        {
+          "name": "ToNorth",
+          "link": ""
+        },
+        {
+          "name": "ToCave",
+          "link": ""
+        }
+      ],
+      "name": "Port"
+    },
+    {
+      "chests": [],
+      "doors": [],
+      "name": "AnoukiChiefHouse"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.wip-json
+++ b/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.wip-json
@@ -1,0 +1,82 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Cannon",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "BeeChest",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "NearRocks",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "HouseLeft",
+          "link": ""
+        },
+        {
+          "name": "GrottoEntry",
+          "link": ""
+        },
+        {
+          "name": "GrottoStairs",
+          "link": ""
+        },
+        {
+          "name": "HouseRight",
+          "link": ""
+        }
+      ],
+      "name": "Outside"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        },
+        {
+          "name": "ToRight",
+          "link": ""
+        }
+      ],
+      "name": "EddoHouseLeft"
+    },
+    {
+      "chests": [
+        {
+          "name": "Cannon",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "SalvageArm",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Exit",
+          "link": ""
+        },
+        {
+          "name": "ToLeft",
+          "link": ""
+        }
+      ],
+      "name": "EddoHouseRight"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SW Sea/Cannon Island/CannonGrotto.wip-json
+++ b/shuffler/auxiliary/SW Sea/Cannon Island/CannonGrotto.wip-json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "CannonGrotto",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "AfterWall",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Down",
+          "link": ""
+        },
+        {
+          "name": "Stairs",
+          "link": ""
+        }
+      ],
+      "name": "Main"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SW Sea/Isle of Ember/Ember.wip-json
+++ b/shuffler/auxiliary/SW Sea/Isle of Ember/Ember.wip-json
@@ -1,0 +1,133 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Ember",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Hook",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Boat",
+          "link": ""
+        },
+        {
+          "name": "Astrid",
+          "link": ""
+        },
+        {
+          "name": "Kayo",
+          "link": ""
+        },
+        {
+          "name": "EmptyHouse",
+          "link": ""
+        },
+        {
+          "name": "RightLowerBottom",
+          "link": ""
+        },
+        {
+          "name": "RightTop",
+          "link": ""
+        },
+        {
+          "name": "RightLowerTop",
+          "link": ""
+        },
+        {
+          "name": "RightMiddleTop",
+          "link": ""
+        },
+        {
+          "name": "RightMiddleBottom",
+          "link": ""
+        },
+        {
+          "name": "RightHigherBottom",
+          "link": ""
+        },
+        {
+          "name": "RightHighestBottom",
+          "link": ""
+        },
+        {
+          "name": "RightHighestTop",
+          "link": ""
+        }
+      ],
+      "name": "EmberLeft"
+    },
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "LeftLowerToppest",
+          "link": ""
+        },
+        {
+          "name": "LeftLowerTop",
+          "link": ""
+        },
+        {
+          "name": "LeftLowerBottom",
+          "link": ""
+        },
+        {
+          "name": "LeftMiddleBottom",
+          "link": ""
+        },
+        {
+          "name": "EmberTemple",
+          "link": ""
+        },
+        {
+          "name": "LeftHigherBottom",
+          "link": ""
+        },
+        {
+          "name": "LeftHigherTop",
+          "link": ""
+        },
+        {
+          "name": "LeftHighestTop",
+          "link": ""
+        },
+        {
+          "name": "LeftHighestBottom",
+          "link": ""
+        }
+      ],
+      "name": "EmberRight"
+    },
+    {
+      "chests": [
+        {
+          "name": "AstridPowerGem",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToOutside",
+          "link": ""
+        },
+        {
+          "name": "ToBasement",
+          "link": ""
+        }
+      ],
+      "name": "AstridHouse"
+    },
+    {
+      "chests": [],
+      "doors": [],
+      "name": "AstridBasement"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SW Sea/Molida Island/Molida.wip-json
+++ b/shuffler/auxiliary/SW Sea/Molida Island/Molida.wip-json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "Molida",
+  "rooms": [
+    {
+      "chests": [],
+      "doors": [
+        {
+          "name": "LeftmostHouse",
+          "link": ""
+        },
+        {
+          "name": "MiddleHouse",
+          "link": ""
+        },
+        {
+          "name": "MolidaShop",
+          "link": ""
+        },
+        {
+          "name": "RomanoHouse",
+          "link": ""
+        },
+        {
+          "name": "ToUpperIsland",
+          "link": ""
+        }
+      ],
+      "name": "Town"
+    },
+    {
+      "chests": [
+        {
+          "name": "Cliff",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "ToCaveSystemRight",
+          "link": ""
+        },
+        {
+          "name": "ToLowerIsland",
+          "link": ""
+        },
+        {
+          "name": "ToCaveSystemLeft",
+          "link": ""
+        }
+      ],
+      "name": "UpperIsland"
+    }
+  ]
+}

--- a/shuffler/auxiliary/SW Sea/Spirit Isle/SpiritIsle.wip-json
+++ b/shuffler/auxiliary/SW Sea/Spirit Isle/SpiritIsle.wip-json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../../aux-schema.json",
+  "name": "SpiritIsle",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Power1",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Power2",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Wisdom1",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Widsom2",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Courage1",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Courage2",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Outside",
+          "link": ""
+        }
+      ],
+      "name": "Inside"
+    },
+    {
+      "chests": [
+        {
+          "name": "LeftSide #Courage Gem",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "AfterJumps #Wisdom Gem",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "Grotto",
+          "link": ""
+        },
+        {
+          "name": "Ship",
+          "link": ""
+        }
+      ],
+      "name": "Outside"
+    }
+  ]
+}

--- a/shuffler/auxiliary/Sea.wip-json
+++ b/shuffler/auxiliary/Sea.wip-json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../aux-schema.json",
+  "name": "Sea",
+  "rooms": [
+    {
+      "chests": [
+        {
+          "name": "Treasure1",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure2",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure3",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure4",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "SunKey",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure5",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure6",
+          "type": "",
+          "contents": ""
+        },
+        {
+          "name": "Treasure7",
+          "type": "",
+          "contents": ""
+        }
+      ],
+      "doors": [
+        {
+          "name": "MercayPort",
+          "link": ""
+        },
+        {
+          "name": "CannonIslePort",
+          "link": ""
+        },
+        {
+          "name": "EmberPort",
+          "link": ""
+        },
+        {
+          "name": "SpiritIslePort",
+          "link": ""
+        },
+        {
+          "name": "MolidaPort",
+          "link": ""
+        }
+      ],
+      "name": "SW"
+    }
+  ]
+}

--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -48,7 +48,7 @@ def logic_to_aux(logic_directory: str, output: str | None):
             rooms[node.room] = room
 
         for room_name, room_content in rooms.items():
-            current_rooms = logic.get("rooms") or []
+            current_rooms = logic.get("rooms", [])
 
             room_content["name"] = room_name
 

--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -33,10 +33,10 @@ def logic_to_aux(logic_directory: str, output: str | None):
         }
 
         for node in nodes:
-            room = rooms.get(node.room) or {}
+            room = rooms.get(node.room, {})
 
-            chests = room.get("chests") or []
-            doors = room.get("doors") or []
+            chests = room.get("chests", [])
+            doors = room.get("doors", [])
             for content in node.contents:
                 match content.type:
                     case "chest":

--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -1,0 +1,85 @@
+import json
+from os import path
+from pathlib import Path
+import sys
+from typing import Any
+
+from _parser import clear_nodes, parse_area
+import click
+
+
+def logic_to_aux(logic_directory: str, output: str | None):
+    logic_files = list(Path(logic_directory).rglob("*.logic"))
+
+    for file in logic_files:
+        file_directory = file.relative_to(logic_directory)
+
+        rooms: dict[str, dict[str, Any]] = {}
+        with open(file, "r") as fd:
+            lines = [line.strip() for line in fd.readlines() if line and line.strip()]
+        clear_nodes()
+        nodes = parse_area(lines)
+
+        path_to_schema = "../"
+        directories_in_between = max(
+            str(file_directory).count("/"), str(file_directory).count("\\")
+        )
+
+        for _ in range(directories_in_between):
+            path_to_schema += "../"
+        path_to_schema += "aux-schema.json"
+
+        logic: dict[str, Any] = {
+            "$schema": str(path_to_schema),
+            "name": nodes[0].area,
+        }
+
+        for node in nodes:
+            room = rooms.get(node.room) or {}
+
+            chests = room.get("chests") or []
+            doors = room.get("doors") or []
+            for content in node.contents:
+                match content.type:
+                    case "chest":
+                        chests.append({"name": content.data, "type": "", "contents": ""})
+                    case "door":
+                        doors.append({"name": content.data, "link": ""})
+            room["chests"] = chests
+            room["doors"] = doors
+            rooms[node.room] = room
+
+        for room_name, room_content in rooms.items():
+            current_rooms = logic.get("rooms") or []
+
+            room_content["name"] = room_name
+
+            current_rooms.append(room_content)
+
+            logic["rooms"] = current_rooms
+
+        if output == "--":
+            print(json.dumps(logic, indent=2), file=sys.stdout)
+        elif output is not None:
+            output_path = Path(output).joinpath(str(file_directory).split(".")[0] + ".wip-json")
+            Path(path.dirname(output_path)).mkdir(parents=True, exist_ok=True)
+
+            with open(output_path, "w") as fd:
+                fd.write(json.dumps(logic, indent=2))
+
+
+@click.command()
+@click.option("-l", "--logic-directory", required=True, type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    default=None,
+    type=click.Path(exists=False, dir_okay=True, file_okay=False),
+    help="Path to save aux data to. Use -- to output to stdout.",
+)
+def logic_to_aux_cli(logic_directory: str, output: str | None):
+    return logic_to_aux(logic_directory, output)
+
+
+if __name__ == "__main__":
+    logic_to_aux_cli()

--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -21,9 +21,7 @@ def logic_to_aux(logic_directory: str, output: str | None):
         nodes = parse_area(lines)
 
         path_to_schema = "../"
-        directories_in_between = max(
-            str(file_directory).count("/"), str(file_directory).count("\\")
-        )
+        directories_in_between = str(file_directory.as_posix()).count("/")
 
         for _ in range(directories_in_between):
             path_to_schema += "../"


### PR DESCRIPTION
This PR creates a tool that can create auxiliary data stubs that can be filled in much easier than manually creating these files. I also added all the currently created stubs. They are automatically created with the `.wip-json` file ending to not be picked up by the shuffler by accident. Together with mikes chest finding tool, this should speed up the creation of the aux data by a large margin.