### PR TITLE
Update aux schema to support entrance randomizer

### DIFF
--- a/shuffler/aux_models.py
+++ b/shuffler/aux_models.py
@@ -43,8 +43,8 @@ class OnEnemy(Check):
 
 
 class Door(BaseModel):
-    name: str = Field(..., description="The name of this door")
-    link: str = Field(..., description="Descriptor where the door leads")
+    name: str = Field(..., description="The name of this exit")
+    link: str = Field(..., description="The `entrance` or `door` where this exit leads.")
 
 
 class Room(BaseModel):
@@ -57,7 +57,7 @@ class Room(BaseModel):
     )
     doors: list[Door] = Field(
         ...,
-        description="All doors that lead to a different room or area",
+        description="All doors in this room that lead to a different room or area",
         min_items=1,
         unique_items=True,
     )

--- a/shuffler/aux_schema.json
+++ b/shuffler/aux_schema.json
@@ -227,12 +227,12 @@
       "properties": {
         "name": {
           "title": "Name",
-          "description": "The name of this door",
+          "description": "The name of this exit",
           "type": "string"
         },
         "link": {
           "title": "Link",
-          "description": "Descriptor where the door leads",
+          "description": "The `entrance` or `door` where this exit leads.",
           "type": "string"
         }
       },
@@ -281,7 +281,7 @@
         },
         "doors": {
           "title": "Doors",
-          "description": "All doors that lead to a different room or area",
+          "description": "All doors in this room that lead to a different room or area",
           "minItems": 1,
           "uniqueItems": true,
           "type": "array",

--- a/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
+++ b/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
@@ -3,6 +3,7 @@
   "name": "Cannon",
   "rooms": [
     {
+      "name": "Outside",
       "chests": [
         {
           "name": "BeeChest",
@@ -22,41 +23,41 @@
       "doors": [
         {
           "name": "Boat",
-          "link": "Sea.SW.East"
+          "link": "Sea.SW.CannonIsle.CannonIslePort"
         },
         {
           "name": "HouseLeft",
-          "link": "EddoHouseLeft.Main"
+          "link": "EddoHouseLeft.Main.Exit"
         },
         {
           "name": "GrottoEntry",
-          "link": "CannonGrotto.Main.Main"
+          "link": "CannonGrotto.Main.Main.Down"
         },
         {
           "name": "GrottoStairs",
-          "link": "CannonGrotto.Main.Main"
+          "link": "CannonGrotto.Main.Main.Stairs"
         },
         {
           "name": "HouseRight",
-          "link": "EddoHouseRight.Main"
+          "link": "EddoHouseRight.Main.Exit"
         }
-      ],
-      "name": "Outside"
+      ]
     },
     {
+      "name": "EddoHouseLeft",
       "doors": [
         {
           "name": "Exit",
-          "link": "Outside.Port"
+          "link": "Outside.Port.HouseLeft"
         },
         {
           "name": "ToRight",
-          "link": "EddoHouseRight.Main"
+          "link": "EddoHouseRight.Main.ToLeft"
         }
-      ],
-      "name": "EddoHouseLeft"
+      ]
     },
     {
+      "name": "EddoHouseRight",
       "chests": [
         {
           "name": "Cannon",
@@ -76,14 +77,13 @@
       "doors": [
         {
           "name": "Exit",
-          "link": "Outside.BombGarden"
+          "link": "Outside.BombGarden.HouseRight"
         },
         {
           "name": "ToLeft",
-          "link": "EddoHouseLeft.ToEddo"
+          "link": "EddoHouseLeft.ToEddo.ToRight"
         }
-      ],
-      "name": "EddoHouseRight"
+      ]
     }
   ]
 }

--- a/shuffler/auxiliary/SW Sea/Mercay Island/Mercay.json
+++ b/shuffler/auxiliary/SW Sea/Mercay Island/Mercay.json
@@ -16,19 +16,23 @@
       "doors": [
         {
           "name": "North",
-          "link": "EnemyBamboo.South"
+          "link": "EnemyBamboo.South.South"
         },
         {
           "name": "OshussHouse",
-          "link": "OshussHouse.Main"
+          "link": "OshussHouse.Main.Outside"
         },
         {
           "name": "RockHouse",
-          "link": "RockHouse.Main"
+          "link": "RockHouse.Main.Outside"
         },
         {
           "name": "East",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.West"
+        },
+        {
+          "name": "OshusCave",
+          "link": "OshusCave.Main.Exit"
         }
       ]
     },
@@ -37,7 +41,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "OutsideOshus.Outside"
+          "link": "OutsideOshus.Outside.OshussHouse"
         }
       ]
     },
@@ -54,40 +58,44 @@
       ],
       "doors": [
         {
+          "name": "Grotto",
+          "link": "MercayGrotto.F2.EastExit.East"
+        },
+        {
           "name": "Tavern",
-          "link": "Tavern.Main"
+          "link": "Tavern.Main.Outside"
         },
         {
           "name": "Shop",
-          "link": "MercayShop.Main"
+          "link": "MercayShop.Main.Outside"
         },
         {
           "name": "Shipyard",
-          "link": "Shipyard.Main"
+          "link": "Shipyard.Main.Outside"
         },
         {
           "name": "House",
-          "link": "MercayHouse.Main"
+          "link": "MercayHouse.Main.Outside"
         },
         {
           "name": "TreasureSelling",
-          "link": "TreasureSelling.Main"
+          "link": "TreasureSelling.Main.Outside"
         },
         {
           "name": "Boat",
-          "link": "Sea.SW.East"
+          "link": "Sea.SW.Mercay.MercayPort"
         },
         {
           "name": "West",
-          "link": "OutsideOshus.East"
+          "link": "OutsideOshus.East.East"
         },
         {
           "name": "NorthMain",
-          "link": "AboveMercayTown.Main"
+          "link": "AboveMercayTown.Main.South"
         },
         {
           "name": "NorthLedge",
-          "link": "AboveMercayTown.Ledge"
+          "link": "AboveMercayTown.Ledge.SouthLedge"
         }
       ]
     },
@@ -105,7 +113,7 @@
       "doors": [
         {
           "name": "Exit",
-          "link": "OutsideOshus.Outside"
+          "link": "OutsideOshus.Outside.OshusCave"
         }
       ]
     },
@@ -114,11 +122,11 @@
       "doors": [
         {
           "name": "South",
-          "link": "OutsideOshus.Outside"
+          "link": "OutsideOshus.Outside.North"
         },
         {
           "name": "Grotto",
-          "link": "MercayGrotto.F1.Lower"
+          "link": "MercayGrotto.F1.Lower.West"
         }
       ]
     },
@@ -157,7 +165,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.Shop"
         }
       ]
     },
@@ -166,7 +174,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.Tavern"
         }
       ]
     },
@@ -175,7 +183,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.TreasureSelling"
         }
       ]
     },
@@ -184,7 +192,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.House"
         }
       ]
     },
@@ -193,7 +201,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.Shipyard"
         }
       ]
     },
@@ -202,7 +210,7 @@
       "doors": [
         {
           "name": "Outside",
-          "link": "OutsideOshus.Outside"
+          "link": "OutsideOshus.Outside.RockHouse"
         }
       ]
     },
@@ -211,27 +219,27 @@
       "doors": [
         {
           "name": "South",
-          "link": "MercayTown.Main"
+          "link": "MercayTown.Main.NorthMain"
         },
         {
           "name": "West",
-          "link": "PathToToTOK.Main"
+          "link": "PathToToTOK.Main.East"
         },
         {
           "name": "ToBridgeCave",
-          "link": "BridgeCave.Main"
+          "link": "BridgeCave.Main.West"
         },
         {
           "name": "Grotto",
-          "link": "GrottoToLedge.Down"
+          "link": "GrottoToLedge.Down.South"
         },
         {
           "name": "SouthLedge",
-          "link": "MercayTown.Ledge"
+          "link": "MercayTown.Ledge.NorthLedge"
         },
         {
           "name": "IslandGrotto",
-          "link": "BridgeCave.Main"
+          "link": "BridgeCave.Main.East"
         }
       ],
       "chests": [
@@ -256,15 +264,15 @@
       "doors": [
         {
           "name": "East",
-          "link": "AboveMercayTown.Main"
+          "link": "AboveMercayTown.Main.West"
         },
         {
           "name": "ToTOK",
-          "link": "TempleOfTheOceanKingLobby.Main.Main"
+          "link": "TempleOfTheOceanKingLobby.Main.Main.Outside"
         },
         {
           "name": "Grotto",
-          "link": "GrottoToLedge.Up"
+          "link": "GrottoToLedge.Up.Left"
         }
       ]
     },
@@ -282,11 +290,11 @@
       "doors": [
         {
           "name": "Left",
-          "link": "PathToToTOK.Main"
+          "link": "PathToToTOK.BombableWall.Grotto"
         },
         {
           "name": "South",
-          "link": "AboveMercayTown.Ledge"
+          "link": "AboveMercayTown.Ledge.Grotto"
         }
       ]
     },
@@ -304,11 +312,11 @@
       "doors": [
         {
           "name": "West",
-          "link": "AboveMercayTown.Main"
+          "link": "AboveMercayTown.HiddenBombableWall.ToBridgeCave"
         },
         {
           "name": "East",
-          "link": "AboveMercayTown.Island"
+          "link": "AboveMercayTown.Island.IslandGrotto"
         }
       ]
     }

--- a/shuffler/auxiliary/SW Sea/Mercay Island/MercayGrotto.json
+++ b/shuffler/auxiliary/SW Sea/Mercay Island/MercayGrotto.json
@@ -1,60 +1,64 @@
 {
-    "$schema": "../../../aux_schema.json",
-    "name": "MercayGrotto",
-    "rooms": [
+  "$schema": "../../../aux_schema.json",
+  "name": "MercayGrotto",
+  "rooms": [
+    {
+      "name": "F1",
+      "chests": [
         {
-            "name": "F1",
-            "chests": [
-                {
-                    "name": "KeyChest",
-                    "type": "chest",
-                    "contents": "small_key",
-                    "zmb_file_path": "Map/dngn_first/map00.bin/zmb/dngn_first_00.zmb",
-                    "zmb_mapobject_index": 21
-                },
-                {
-                    "name": "SecondChest",
-                    "type": "chest",
-                    "contents": "small_red_rupee",
-                    "zmb_file_path": "Map/dngn_first/map00.bin/zmb/dngn_first_00.zmb",
-                    "zmb_mapobject_index": 19
-                },
-                {
-                    "name": "KeyAfter2143",
-                    "type": "freestanding",
-                    "contents": "small_key",
-                    "zmb_file_path": "TODO",
-                    "zmb_mapobject_index": -1
-                }
-            ],
-            "doors": [
-                {
-                    "name": "West",
-                    "link": "Mercay.EnemyBamboo.Grotto"
-                },
-                {
-                    "name": "North",
-                    "link": "Mercay.F2.Main"
-                }
-            ]
+          "name": "KeyChest",
+          "type": "chest",
+          "contents": "small_key",
+          "zmb_file_path": "Map/dngn_first/map00.bin/zmb/dngn_first_00.zmb",
+          "zmb_mapobject_index": 21
         },
         {
-            "name": "F2",
-            "chests": [
-                {
-                    "name": "SmallKey",
-                    "type": "on_enemy",
-                    "contents": "small_key",
-                    "zmb_file_path": "TODO",
-                    "zmb_mapobject_index": -1
-                }
-            ],
-            "doors": [
-                {
-                    "name": "East",
-                    "link": "Mercay.MercayTown.Main"
-                }
-            ]
+          "name": "SecondChest",
+          "type": "chest",
+          "contents": "small_red_rupee",
+          "zmb_file_path": "Map/dngn_first/map00.bin/zmb/dngn_first_00.zmb",
+          "zmb_mapobject_index": 19
+        },
+        {
+          "name": "KeyAfter2143",
+          "type": "freestanding",
+          "contents": "small_key",
+          "zmb_file_path": "TODO",
+          "zmb_mapobject_index": -1
         }
-    ]
+      ],
+      "doors": [
+        {
+          "name": "West",
+          "link": "Mercay.EnemyBamboo.Grotto.Grotto"
+        },
+        {
+          "name": "North",
+          "link": "F2.Main.Downstairs"
+        }
+      ]
+    },
+    {
+      "name": "F2",
+      "chests": [
+        {
+          "name": "SmallKey",
+          "type": "on_enemy",
+          "contents": "small_key",
+          "zmb_file_path": "TODO",
+          "zmb_mapobject_index": -1
+        }
+      ],
+      "doors": [
+        {
+          "name": "Downstairs",
+          "link": "F1.NorthDoor.North"
+        },
+        {
+          "name": "East",
+          "link": "Mercay.MercayTown.Main.Grotto"
+        }
+      ]
+    }
+  ]
 }

--- a/shuffler/logic/SW Sea/Mercay Island/Mercay.logic
+++ b/shuffler/logic/SW Sea/Mercay Island/Mercay.logic
@@ -5,6 +5,7 @@ area Mercay:
       door North
       door OshussHouse
       door RockHouse
+      door OshusCave
     node East:
       door East
     Outside <-> East: flag BridgeRepaired
@@ -15,6 +16,7 @@ area Mercay:
 
   room MercayTown:
     node Main:
+      door Grotto
       door Tavern
       door Shop
       door Shipyard

--- a/shuffler/main.py
+++ b/shuffler/main.py
@@ -165,6 +165,11 @@ def traverse_graph(
                                 for other_node in nodes:
                                     link = door.link
 
+                                    # Remove the `door`/`entrance` that this `door`/`exit` links to.
+                                    # It is only used for entrance randomization; for chest
+                                    # randomization, we don't care about it.
+                                    link = ".".join(link.split(".")[:-1])
+
                                     # TODO: remove this if statement once aux data is complete
                                     if "todo" in link.lower():
                                         continue


### PR DESCRIPTION
Currently, we support connecting two `rooms` with `doors`/`exits`. But in order to support entrance randomizer, more info is needed. Saying that `room A` and `room B` are connected by `door C` isn't sufficient, since `room B` may have more than one door. Instead, the shuffler needs to know which `door`/`entrance` `door C` is connected to. 

The logic format actually supports this with the distinction between `entrance`/`exit`/`door`, I just didn't pick up on it until now :)