### PR TITLE
Add validation for `doors` to `Area` model

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -133,9 +133,11 @@ jobs:
       - name: Upgrade pip
         run: pip install --upgrade pip --user
 
+      - name: Install dependencies
+        run: pip install -e .
+
       - name: Check if there are changes to pydantic models that aren't reflected in JSON schema
         run: |
-          pip install pydantic
           python shuffler/aux_models.py
           git diff --exit-code
           if [ $? -ne 0 ] 

--- a/shuffler/aux_models.py
+++ b/shuffler/aux_models.py
@@ -1,6 +1,12 @@
+import os
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
+
+from shuffler._parser import Descriptor, parse
+
+AUX_DATA_DIRECTORY = os.environ.get("AUX_DATA_DIRECTORY", Path(__file__).parent / "auxiliary")
+LOGIC_DATA_DIRECTORY = os.environ.get("LOGIC_DATA_DIRECTORY", Path(__file__).parent / "logic")
 
 
 class Check(BaseModel):
@@ -68,6 +74,36 @@ class Area(BaseModel):
     rooms: list[Room] = Field(
         ..., description="All of the rooms inside this area", min_items=1, unique_items=True
     )
+
+    @validator("rooms")
+    def check_if_doors_are_consistent_between_aux_data_and_logic(
+        cls, v: list[Room], values  # noqa: N805
+    ):
+        """Check that all doors/exits in the aux data are also in the logic (and vice-versa)."""
+        nodes, _ = parse(Path(LOGIC_DATA_DIRECTORY))
+        for room in v:
+            # Get all doors in the logic
+            logic_doors = set()
+            for node in nodes:
+                if node.area != values["name"] or node.room != room.name:
+                    continue
+                for contents in node.contents:
+                    if contents.type in (Descriptor.DOOR.value, Descriptor.EXIT.value):
+                        logic_doors.add(contents.data)
+
+            # Get all doors in the aux data
+            aux_data_doors = set([door.name for door in room.doors])
+
+            # Make sure they are the same.
+            # If not, display the differences.
+            assert logic_doors == aux_data_doors, (
+                "The following doors were found in the logic but not the aux data: "
+                f"{logic_doors - aux_data_doors or '{}'}"
+                "\nThe following doors were found in the aux data but not the logic: "
+                f"{aux_data_doors - logic_doors or '{}'}"
+            )
+
+        return v
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pydantic's validation allows you to do even stricter checks on data than what JSON schema allows. Here, I've added a check that, for every `area`, ensures every `door` or `exit` in that `area` is present in both the aux data and logic. If there's a door in the aux data that's not in the logic (or vice versa), this will cause all sorts of test failures since these validators run whenever the aux data is parsed (so, any shuffler tests will likely fail for example), which is a good thing.

Later on, we'll likely want to disable these checks for performance reasons in actual releases. I'm not sure if pydantic allows them to be disabled, if not I guess this can be done with an environment variable.