### PR TITLE
Update to `ndspy` 4.0.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-add-repository https://dl.winehq.org/wine-builds/debian/
 RUN apt-get update && apt-get install -y winehq-stable
 # Install python dependencies
 RUN apt-get install -y python3-pip python3-pil
-RUN pip3 install click ndspy==3.0.0
+RUN pip3 install click ndspy==4.0.0
 ADD misc/* /app/
 ADD src/* /app/src/
 ADD Makefile /app

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "click",
-        "ndspy==3.0.0",
+        "ndspy>=4.0.0",
         "pydantic",
         "zed @ git+https://github.com/phst-randomizer/zed.git",
     ],


### PR DESCRIPTION
This is a prerequisite for #22, since the `code` API functionality mentioned in that issue is only available in `ndspy` 4.0.0.