### PR TITLE
Replace CUE `blz` utility with ndspy CLI

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,8 +16,6 @@ WORKDIR /app
 COPY --from=compile_armips /armips/armips /app
 COPY --from=compile_ndstool /ndstool/ndstool /app
 RUN apt-get update && apt-get install -y gcc software-properties-common
-RUN git clone https://github.com/phst-randomizer/nds-compressors.git
-RUN gcc nds-compressors/blz.c -o blz && chmod +x ./blz
 RUN wget -O fixy9.exe https://github.com/StraDaMa/Legend-of-Zelda-Phantom-Hourglass-D-Pad-Patch/raw/master/fixy9.exe
 RUN dpkg --add-architecture i386 
 RUN wget -qO - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -

--- a/base/Makefile
+++ b/base/Makefile
@@ -41,18 +41,18 @@ arm9.bin overlay: $(INPUT_NDS_FILE) $(OBJ) y9.bin
 	truncate -s -12 arm9_original.bin
 
 	# Decompress BLZ-compressed binaries
-	./blz -d arm9_original.bin
+	ndspy_codeCompression decompress arm9_original.bin arm9_original.bin
 	for file in $$(cat src/main.asm | grep -oP "overlay_(\d+).bin"); do \
-		./blz -d overlay/$$file; \
+		ndspy_codeCompression decompress overlay/$$file overlay/$$file; \
 	done
 
 	# Patch the binaries with our custom code
 	./armips src/main.asm
 
 	# Recompress the binaries
-	./blz -eo arm9_compressed.bin
+	ndspy_codeCompression compress --is_arm9 arm9_compressed.bin arm9_compressed.bin
 	for file in $$(cat src/main.asm | grep -oP "overlay_(\d+).bin"); do \
-		./blz -eo overlay/$$file; \
+		ndspy_codeCompression compress overlay/$$file overlay/$$file; \
 	done
 
 	# Combine arm9.bin back into a single file


### PR DESCRIPTION
Addresses part of #22.

This repo https://github.com/phst-randomizer/nds-compressors should also be deleted (maybe archived? idk, I see no reason to keep it around) once there is reasonable confidence that this works.