### PR TITLE
Make `Room.chests` default to empty list instead of `None`

### DIFF
--- a/shuffler/aux_models.py
+++ b/shuffler/aux_models.py
@@ -55,10 +55,9 @@ class Door(BaseModel):
 
 class Room(BaseModel):
     name: str = Field(..., description="The name of the room")
-    chests: list[Chest | Npc | IslandShop | Tree | Freestanding | OnEnemy] | None = Field(
-        None,
+    chests: list[Chest | Npc | IslandShop | Tree | Freestanding | OnEnemy] = Field(
+        [],
         description="Item checks that can be made in this room",
-        min_items=1,
         unique_items=True,
     )
     doors: list[Door] = Field(

--- a/shuffler/aux_schema.json
+++ b/shuffler/aux_schema.json
@@ -253,7 +253,7 @@
         "chests": {
           "title": "Chests",
           "description": "Item checks that can be made in this room",
-          "minItems": 1,
+          "default": [],
           "uniqueItems": true,
           "type": "array",
           "items": {


### PR DESCRIPTION
This makes it easier to handle parsing aux data in the patcher.