### PR TITLE
Mechanism for optional settings in base patches

### DIFF
--- a/base/src/main.asm
+++ b/base/src/main.asm
@@ -9,10 +9,13 @@
     .org 0x54180 + 0x2004000
         ; Area of unused space in arm9.bin; new code can be stored here
         .area 0x301, 0xFF
+            .fill 0xA, 0x0 ; bitmap for randomizer settings
+
             .arm
             .importobj "src/faster_boat.o"
             .importobj "src/fixed_random_treasure_in_shop.o"
             .importobj "src/progressive_sword_check.o"
+            .importobj "src/rando_settings.o"
             .include "_island_shop_files.asm"
         .endarea
 

--- a/base/src/rando_settings.c
+++ b/base/src/rando_settings.c
@@ -1,0 +1,6 @@
+#include "rando_settings.h"
+
+bool setting_is_enabled(uint8_t offset, uint8_t bit) {
+  uint8_t *base_addr = (uint8_t *)RANDO_SETTINGS_BITMAP_ADDR;
+  return (base_addr[offset] & bit) == bit;
+}

--- a/base/src/rando_settings.h
+++ b/base/src/rando_settings.h
@@ -4,6 +4,9 @@
 // RAM address of bitmap encoding randomizer settings
 #define RANDO_SETTINGS_BITMAP_ADDR 0x2058180
 
+// Randomizer setting flags in format (offset_from_base_address, bit)
+#define MERCAY_BRIDGE_REPAIRED_FROM_START 0, 0x1
+
 /**
  * Check if the randomizer setting represented by the given offset/bit is
  * enabled.

--- a/base/src/rando_settings.h
+++ b/base/src/rando_settings.h
@@ -1,0 +1,17 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+// RAM address of bitmap encoding randomizer settings
+#define RANDO_SETTINGS_BITMAP_ADDR 0x2058180
+
+/**
+ * Check if the randomizer setting represented by the given offset/bit is
+ * enabled.
+ *
+ * @param offset Offset from RANDO_SETTINGS_BITMAP_ADDR of the byte containing
+ * the setting bit
+ * @param bit The bit representing the setting within the
+ * `RANDO_SETTINGS_BITMAP_ADDR[offset]` byte
+ * @return true if setting is enabled, false if it is disabled
+ */
+bool setting_is_enabled(uint8_t offset, uint8_t bit);

--- a/base/src/set_initial_flags.c
+++ b/base/src/set_initial_flags.c
@@ -1,4 +1,5 @@
 #include "flags.h"
+#include "rando_settings.h"
 #include <stdint.h>
 
 __attribute__((always_inline)) static void set_flag(int addr, uint8_t bit) {
@@ -6,6 +7,8 @@ __attribute__((always_inline)) static void set_flag(int addr, uint8_t bit) {
 }
 
 void set_initial_flags(uint32_t base_flag_address) {
-  set_flag(base_flag_address + MERCAY_BRIDGE_REPAIRED);
+  if (setting_is_enabled(MERCAY_BRIDGE_REPAIRED_FROM_START)) {
+    set_flag(base_flag_address + MERCAY_BRIDGE_REPAIRED);
+  }
   // TODO: finish documenting/setting the rest of the needed flags
 }


### PR DESCRIPTION
Reserves some space in memory for storing flags associated with randomizer settings + adds a function to check if a given setting is enabled. Also makes "mercay bridge repaired from beginning" into a setting - if the appropriate bit is set, the bridge is repaired, otherwise it is broken as usual.