### PR TITLE
Fix gcc compilation warnings

### DIFF
--- a/base/src/set_initial_flags.c
+++ b/base/src/set_initial_flags.c
@@ -2,7 +2,7 @@
 #include "rando_settings.h"
 #include <stdint.h>
 
-__attribute__((always_inline)) static void set_flag(int addr, uint8_t bit) {
+static void set_flag(int addr, uint8_t bit) {
   *((uint8_t *)addr) |= bit;
 }
 


### PR DESCRIPTION
This function doesn't need to be inlined.