### PR TITLE
Output a BPS patch instead of a patched ROM in base patch build toolchain

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -186,7 +186,7 @@ jobs:
         id: buildx        
         uses: docker/setup-buildx-action@v2
 
-      - name: Build Docker
+      - name: Build base patch
         uses: docker/build-push-action@v3
         with:
           context: base/
@@ -199,46 +199,10 @@ jobs:
           outputs: |
             base/out
 
-      - name: Clone Flips repo
-        uses: actions/checkout@v3
-        with:
-          repository: Alcaro/Flips
-          path: base/Flips
-
-      - name: Get latest commit hash from Flips repo
-        id: flips-hash
-        shell: bash
-        run: |
-          echo "::set-output name=flips_hash::$(git rev-parse --short HEAD)"
-        working-directory: base/Flips
-
-      - name: Cache Flips executable
-        uses: actions/cache@v3
-        id: flips-cache
-        env:
-          cache-name: cache-flips
-        with:
-          path: base/Flips/*
-          key: ${{ env.cache-name }}-${{ steps.flips-hash.outputs.flips_hash }}-${{ runner.os }}
-
-      - name: Compile Flips tool
-        if: steps.flips-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update && sudo apt-get install g++ build-essential
-          chmod +x ./make.sh
-          ./make.sh
-        working-directory: base/Flips
-
-      - name: Create patch
-        run: |
-          chmod +x ./Flips/flips
-          ./Flips/flips --create $(ls *.nds) out/out.nds patch.bps
-        working-directory: base
-
       - uses: actions/upload-artifact@v3
         with:
           name: patch.bps
-          path: base/patch.bps
+          path: base/out/patch.bps
 
       - name: Cleanup
         if: always()

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,10 +20,9 @@ RUN git clone https://github.com/Alcaro/Flips.git
 RUN chmod +x Flips/make.sh
 RUN cd Flips && ./make.sh
 
-
 FROM devkitpro/devkitarm:latest as build
 WORKDIR /app
-# Copy compiled armips and ndstool binaries from previous stage
+# Copy compiled armips, ndstool, and flips binaries from previous stages
 COPY --from=compile_armips /armips/armips /app
 COPY --from=compile_ndstool /ndstool/ndstool /app
 COPY --from=compile_flips /Flips/flips /app

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,9 +1,11 @@
+# Download and compile ARMIPS
 FROM rikorose/gcc-cmake:gcc-8 AS compile_armips
 RUN git clone --recurse-submodules https://github.com/Kingcom/armips.git
 WORKDIR /armips
 RUN cmake .
 RUN make
 
+# Download and compile ndstool
 FROM ubuntu:20.04 AS compile_ndstool
 RUN apt-get update && apt-get install -y build-essential git gcc g++ autotools-dev autoconf
 RUN git clone https://github.com/devkitPro/ndstool
@@ -13,20 +15,26 @@ RUN aclocal && autoconf && automake --add-missing && chmod +x ./configure &&\
 
 FROM devkitpro/devkitarm:latest as build
 WORKDIR /app
+# Copy compiled armips and ndstool binaries from previous stage
 COPY --from=compile_armips /armips/armips /app
 COPY --from=compile_ndstool /ndstool/ndstool /app
+# Install gcc + software-properties-common (the latter so we can use `apt-add-repository`)
 RUN apt-get update && apt-get install -y gcc software-properties-common
+# Download fixy9 utility for updating y9.bin after making changes to overlays
 RUN wget -O fixy9.exe https://github.com/StraDaMa/Legend-of-Zelda-Phantom-Hourglass-D-Pad-Patch/raw/master/fixy9.exe
-RUN dpkg --add-architecture i386 
+# Install wine
+RUN dpkg --add-architecture i386
 RUN wget -qO - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
 RUN apt-add-repository https://dl.winehq.org/wine-builds/debian/
 RUN apt-get update && apt-get install -y winehq-stable
 # Install python dependencies
 RUN apt-get install -y python3-pip python3-pil
 RUN pip3 install click ndspy==4.0.0
+# Add needed source files to the docker build
 ADD misc/* /app/
 ADD src/* /app/src/
 ADD Makefile /app
+# Create base patch
 ARG PH_ROM_PATH
 ARG VERSION_STRING
 ADD $PH_ROM_PATH /app

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,11 +13,20 @@ WORKDIR /ndstool
 RUN aclocal && autoconf && automake --add-missing && chmod +x ./configure &&\
     ./configure --disable-dependency-tracking && make
 
+# Download and compile Floating IPS patcher
+FROM ubuntu:20.04 as compile_flips
+RUN apt-get update && apt-get install -y git g++ build-essential
+RUN git clone https://github.com/Alcaro/Flips.git
+RUN chmod +x Flips/make.sh
+RUN cd Flips && ./make.sh
+
+
 FROM devkitpro/devkitarm:latest as build
 WORKDIR /app
 # Copy compiled armips and ndstool binaries from previous stage
 COPY --from=compile_armips /armips/armips /app
 COPY --from=compile_ndstool /ndstool/ndstool /app
+COPY --from=compile_flips /Flips/flips /app
 # Install gcc + software-properties-common (the latter so we can use `apt-add-repository`)
 RUN apt-get update && apt-get install -y gcc software-properties-common
 # Download fixy9 utility for updating y9.bin after making changes to overlays
@@ -40,5 +49,6 @@ ARG VERSION_STRING
 ADD $PH_ROM_PATH /app
 RUN make
 
+# Export base patch to host
 FROM scratch
-COPY --from=build /app/out.nds /
+COPY --from=build /app/patch.bps /

--- a/base/Makefile
+++ b/base/Makefile
@@ -21,9 +21,13 @@ ASM=$(SRC:.c=.asm)
 
 INPUT_NDS_FILE=$(PH_ROM_PATH)
 OUTPUT_NDS_FILE=out.nds
+OUTPUT_BPS_FILE=patch.bps
 
 # Set version string to a default if it isn't provided
 VERSION_STRING := $(or $(VERSION_STRING), "no_version")
+
+$(OUTPUT_BPS_FILE): $(INPUT_NDS_FILE) $(OUTPUT_NDS_FILE)
+	./flips --create $^ $@
 
 $(OUTPUT_NDS_FILE): data overlay arm9.bin arm7.bin y9.bin y7.bin banner.bin header.bin
 	./ndstool -c out.nds -9 arm9.bin -7 arm7.bin -y9 y9.bin -y7 y7.bin -d data -y overlay -t banner.bin -h header.bin
@@ -98,4 +102,4 @@ debug: $(OBJ) $(ASM)
 clean:
 	rm -f $(DEST_DIR)/*
 
-all: $(OUTPUT_NDS_FILE)
+all: $(OUTPUT_BPS_FILE)


### PR DESCRIPTION
This will make it easier to integrate the base patch into the patcher.