### PR TITLE
Account for comments in logic_to_aux script

### DIFF
--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -70,6 +70,7 @@ def logic_to_aux(logic_directory: str, output: str | None):
 
             with open(output_path, "w") as fd:
                 fd.write(json.dumps(logic, indent=2))
+                fd.write("\n")
 
 
 @click.command()

--- a/shuffler/logic_to_aux.py
+++ b/shuffler/logic_to_aux.py
@@ -16,7 +16,13 @@ def logic_to_aux(logic_directory: str, output: str | None):
 
         rooms: dict[str, dict[str, Any]] = {}
         with open(file, "r") as fd:
-            lines = [line.strip() for line in fd.readlines() if line and line.strip()]
+            lines: list[str] = []
+            for line in fd.readlines():
+                line = line.strip()  # strip off leading and trailing whitespace
+                if "#" in line:
+                    line = line[: line.index("#")]  # remove any comments
+                if line:
+                    lines.append(line)
         clear_nodes()
         nodes = parse_area(lines)
 


### PR DESCRIPTION
The `logic_to_aux.py` script wasn't properly accounting for comments in .logic files. 

I just copied the comment-handling code from the logic parser. I guess it might be cleaner to refactor the logic parser so the comment-handling code can be reused by this script, but i don't think it's worth doing that for a one-off script