### PR TITLE
Refactor shuffler/patcher logic and aux_data parsing

### DIFF
--- a/patcher/main.py
+++ b/patcher/main.py
@@ -4,14 +4,15 @@ import click
 from ndspy import rom
 
 from patcher._util import load_aux_data, load_rom, patch_rom
+from shuffler.aux_models import Area
 
 
 def patch(
-    aux_data_directory: str, input_rom_path: str, output_rom_path: str | None = None
+    aux_data: list[Area],
+    input_rom: rom.NintendoDSRom,
+    output_rom_path: str | None = None,
 ) -> rom.NintendoDSRom:
-    input_rom = load_rom(Path(input_rom_path))
-    new_aux_data = load_aux_data(Path(aux_data_directory))
-    patched_rom = patch_rom(new_aux_data, input_rom)
+    patched_rom = patch_rom(aux_data, input_rom)
 
     if output_rom_path is not None:
         # Save the ROM to disk
@@ -39,7 +40,10 @@ def patch(
     '-o', '--output-rom-path', default=None, type=str, help='Path to save patched ROM to.'
 )
 def patcher_cli(aux_data_directory: str, input_rom_path: str, output_rom_path: str | None):
-    return patch(aux_data_directory, input_rom_path, output_rom_path)
+    input_rom = load_rom(Path(input_rom_path))
+    new_aux_data = load_aux_data(Path(aux_data_directory))
+
+    return patch(new_aux_data, input_rom, output_rom_path)
 
 
 if __name__ == '__main__':

--- a/shuffler/_parser.py
+++ b/shuffler/_parser.py
@@ -258,7 +258,7 @@ def clear_nodes():
     nodes.clear()
 
 
-def parse(directory: Path):
+def parse(directory: Path) -> tuple[list[Node], dict[str, list[Edge]]]:
     logic_files = list(directory.rglob('*.logic'))
 
     for file in logic_files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ import pytest
 
 from patcher.location_types import DigSpotLocation, IslandShopLocation
 from patcher.location_types.island_shop import GD_MODELS
+from shuffler._parser import Edge, Node, parse
+from shuffler.aux_models import Area
+from shuffler.main import load_aux_data
 
 # Not all tests require py-desmume, so if it's not installed we
 # just silently suppress the error:
@@ -213,7 +216,18 @@ def aux_data_directory(tmp_path: Path):
 
 
 @pytest.fixture
+def aux_data(aux_data_directory: str) -> list[Area]:
+    return load_aux_data(Path(aux_data_directory))
+
+
+@pytest.fixture
 def logic_directory(tmp_path: Path):
     dest = tmp_path / 'logic'
     shutil.copytree(Path(__file__).parent.parent / 'shuffler' / 'logic', dest)
     return str(dest)
+
+
+@pytest.fixture
+def logic(logic_directory: Path) -> tuple[list[Node], dict[str, list[Edge]]]:
+    nodes, edges = parse(Path(logic_directory))
+    return nodes, edges

--- a/tests/test_shuffler.py
+++ b/tests/test_shuffler.py
@@ -74,11 +74,13 @@ def test_parser(tmp_path: Path):
 
 
 @pytest.mark.parametrize('seed', ['test', 'another_test', 'ANOTHER_TEST!!', 'this_is_a_real_seed'])
-def test_seeds(seed: str, aux_data_directory: str, logic_directory: str):
+def test_seeds(seed: str, aux_data: list[Area], logic: tuple[list[Node], dict[str, list[Edge]]]):
     """Test that running the shuffler with the same seed multiple times produces identical aux data."""
-    first = shuffle(seed, aux_data_directory, logic_directory)
-    second = shuffle(seed, aux_data_directory, logic_directory)
-    third = shuffle(seed, aux_data_directory, logic_directory)
+    nodes, edges = logic
+
+    first = shuffle(seed, nodes, edges, aux_data)
+    second = shuffle(seed, nodes, edges, aux_data)
+    third = shuffle(seed, nodes, edges, aux_data)
     assert first == second == third
 
 


### PR DESCRIPTION
Instead of accepting file paths in the `shuffle` and `parse` functions, make the caller do the parsing first. Also, eliminate the use of global variables in the logic parser.

This is a code refactor/cleanup to make implementing #119 easier.