### PR TITLE
Fix treasure map name in aux data

### DIFF
--- a/patcher/_items.py
+++ b/patcher/_items.py
@@ -32,6 +32,6 @@ ITEMS = {
     'courage_gem': 0x2F,
     'common_treasure': 0x30,  # TODO: randomize this at run-time
     'salvage_arm': 0x3D,
-    'treasure_map_8': 0x52,
+    'treasure_map_SW_7': 0x52,
     'sand_of_hours': 0x78,
 }

--- a/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
+++ b/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
@@ -8,7 +8,7 @@
         {
           "name": "BeeChest",
           "type": "chest",
-          "contents": "treasure_map_8",
+          "contents": "treasure_map_SW_7",
           "zmb_file_path": "Map/isle_torii/map00.bin/zmb/isle_torii_00.zmb",
           "zmb_mapobject_index": 183
         },


### PR DESCRIPTION
Treasure map names should correspond to the region/number of the salvage chests they lead to.