### PR TITLE
Add `strcpy` address to base patch code

### DIFF
--- a/base/src/ph.asm
+++ b/base/src/ph.asm
@@ -2,6 +2,7 @@
 ; this enables them to be called from C code.
 
 .definelabel strlen, 0x2046fc4
+.definelabel strcpy, 0x2046fe0
 .definelabel strcat, 0x20470f8
 .definelabel sprintf, 0x200c8d0
 .definelabel get_npc_address, 0x203e824

--- a/base/src/ph.h
+++ b/base/src/ph.h
@@ -4,6 +4,7 @@
 // definitions, etc that are present in the base game.
 
 extern void strcat(char *dest, char *src);
+extern void strcpy(char *dest, char *src);
 extern int32_t strlen(char *s);
 
 // TODO: verify this is correct. I'm not sure if this


### PR DESCRIPTION
I found an implementation of `strcpy` in arm9.bin, might as well add it to our header file in case it's useful.