### PR TITLE
Move test dependencies from `tox.ini` to `test` target in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,11 @@ setup(
         'vidua==0.4.4',
         'zed @ git+https://github.com/phst-randomizer/zed.git@b6b654a0a40b2f4dfb6d2b3692bd245ae0f6975b',  # noqa: E501
     ],
+    extras_require={
+        'test': [
+            'pytest==7.1.3',
+            'pytest-xdist==2.5.0',
+            'py-desmume==0.0.5',
+        ],
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ envlist =
     test-desmume,
 
 [testenv:test]
-deps =
-    pytest
-    pytest-xdist
+extras =
+    test
 commands =
     pytest --numprocesses auto {posargs} --ignore=tests/desmume
 
@@ -14,10 +13,8 @@ commands =
 passenv =
     PH_ROM_PATH
     PY_DESMUME_BATTERY_DIR
-deps =
-    pytest
-    pytest-xdist
-    py-desmume>=0.0.4.post2
+extras =
+    test
 commands =
     pytest --numprocesses auto {posargs} tests/desmume
 


### PR DESCRIPTION
py-desmume had a bug fix in the latest release, but `tox` wasn't picking it up in my local environment since it still had the older version cached. This PR moves py-desmume and the other test-only dependencies to `setup.py` so their versions can be tracked and upgraded as needed.