### PR TITLE
Auto merge `pre-commit `dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,13 @@
   ],
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchPaths": [
+        "+(.pre-commit-config.yaml)"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
This changes the Renovate config so that any updates to `pre-commit` dependencies are automatically merged, provided that tests pass. Nothing in `.pre-commit-config.yaml` actually impacts the functionality of the randomizer application, it's all just code style/linting checks. So, it should always be safe to merge these kind of changes without human review. 
Application dependencies like Python libraries, Docker images, etc. will still require approval and manual merging by a human developer.