### PR TITLE
Fix CI triggers so they run on PRs from forks too

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,6 +1,9 @@
 name: build-test-release
 on:
   push:
+    branches:
+      - main
+  pull_request:
 jobs:
   lint-type-check:
     name: Lint and type check code


### PR DESCRIPTION
As seen in #170, CI is setup incorrectly and doesn't run if a PR based on a fork is opened. 