### PR TITLE
Rename `npc` items to `event` items

### DIFF
--- a/patcher/_util.py
+++ b/patcher/_util.py
@@ -16,7 +16,7 @@ from patcher.location_types import (
     MapObjectLocation,
     SalvageTreasureLocation,
 )
-from shuffler.aux_models import Area, Chest, DigSpot, IslandShop, Npc, SalvageTreasure, Tree
+from shuffler.aux_models import Area, Chest, DigSpot, Event, IslandShop, SalvageTreasure, Tree
 
 
 def is_frozen():
@@ -79,11 +79,11 @@ def patch_tree(tree: Tree):
     location.set_location(ITEMS[tree.contents])
 
 
-def patch_npc(npc: Npc):
+def patch_event(event: Event):
     location = EventLocation(
-        instruction_index=npc.bmg_instruction_index, file_path=npc.bmg_file_path
+        instruction_index=event.bmg_instruction_index, file_path=event.bmg_file_path
     )
-    location.set_location(ITEMS[npc.contents])
+    location.set_location(ITEMS[event.contents])
 
 
 def patch_island_shop(shop_item: IslandShop):
@@ -128,9 +128,9 @@ def patch_rom(aux_data: list[Area], input_rom: rom.NintendoDSRom) -> rom.Nintend
                     case 'chest':
                         assert isinstance(chest, Chest)
                         patch_chest(chest)
-                    case 'npc':
-                        assert isinstance(chest, Npc)
-                        patch_npc(chest)
+                    case 'event':
+                        assert isinstance(chest, Event)
+                        patch_event(chest)
                     case 'island_shop':
                         assert isinstance(chest, IslandShop)
                         patch_island_shop(chest)

--- a/shuffler/aux_models.py
+++ b/shuffler/aux_models.py
@@ -44,8 +44,8 @@ class Tree(Chest):
     type = Field('tree', const=True)
 
 
-class Npc(Check):
-    type = Field('npc', const=True)
+class Event(Check):
+    type = Field('event', const=True)
     bmg_file_path: str = Field(..., description='File path to the bmg the instruction is on')
     bmg_instruction_index: int = Field(
         ..., description='Index of the instruction in the defined bmg file'
@@ -88,7 +88,7 @@ class Door(BaseModel):
 class Room(BaseModel):
     name: str = Field(..., description='The name of the room')
     chests: list[
-        Chest | Npc | IslandShop | Tree | Freestanding | OnEnemy | SalvageTreasure | DigSpot
+        Chest | Event | IslandShop | Tree | Freestanding | OnEnemy | SalvageTreasure | DigSpot
     ] = Field(
         [],
         description='Item checks that can be made in this room',

--- a/shuffler/aux_schema.json
+++ b/shuffler/aux_schema.json
@@ -61,8 +61,8 @@
         "zmb_mapobject_index"
       ]
     },
-    "Npc": {
-      "title": "Npc",
+    "Event": {
+      "title": "Event",
       "type": "object",
       "properties": {
         "name": {
@@ -87,8 +87,8 @@
         },
         "type": {
           "title": "Type",
-          "default": "npc",
-          "const": "npc",
+          "default": "event",
+          "const": "event",
           "type": "string"
         }
       },
@@ -344,7 +344,7 @@
                 "$ref": "#/definitions/Chest"
               },
               {
-                "$ref": "#/definitions/Npc"
+                "$ref": "#/definitions/Event"
               },
               {
                 "$ref": "#/definitions/IslandShop"

--- a/shuffler/auxiliary/NW Sea/Bannan Island/Bannan.json
+++ b/shuffler/auxiliary/NW Sea/Bannan Island/Bannan.json
@@ -36,7 +36,7 @@
       "chests": [
         {
           "name": "CannonMiniGameBombBag",
-          "type": "npc",
+          "type": "event",
           "contents": "todo",
           "bmg_file_path": "todo",
           "bmg_instruction_index": -1
@@ -89,7 +89,7 @@
       "chests": [
         {
           "name": "FishingRodFromOldMan",
-          "type": "npc",
+          "type": "event",
           "contents": "fishing_rod",
           "bmg_instruction_index": 87,
           "bmg_file_path": "English/Message/hidari.bmg"

--- a/shuffler/auxiliary/NW Sea/Uncharted Island/Uncharted.json
+++ b/shuffler/auxiliary/NW Sea/Uncharted Island/Uncharted.json
@@ -29,7 +29,7 @@
       "chests": [
         {
           "name": "CycloneSlate",
-          "type": "npc",
+          "type": "event",
           "contents": "cyclone_slate",
           "bmg_file_path": "English/Message/kojima3.bmg",
           "bmg_instruction_index": 108

--- a/shuffler/auxiliary/NW Sea/Zauz Island/Zauz.json
+++ b/shuffler/auxiliary/NW Sea/Zauz Island/Zauz.json
@@ -36,7 +36,7 @@
       "chests": [
         {
           "name": "ZauzPhantomSword",
-          "type": "npc",
+          "type": "event",
           "contents": "TODO",
           "bmg_file_path": "English/Message/sennin.bmg",
           "bmg_instruction_index": -1

--- a/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
+++ b/shuffler/auxiliary/SW Sea/Cannon Island/Cannon.json
@@ -61,14 +61,14 @@
       "chests": [
         {
           "name": "Cannon",
-          "type": "npc",
+          "type": "event",
           "contents": "cannon",
           "bmg_file_path": "English/Message/torii.bmg",
           "bmg_instruction_index": 35
         },
         {
           "name": "SalvageArm",
-          "type": "npc",
+          "type": "event",
           "contents": "salvage_arm",
           "bmg_file_path": "English/Message/torii.bmg",
           "bmg_instruction_index": 73

--- a/shuffler/auxiliary/SW Sea/Mercay Island/Mercay.json
+++ b/shuffler/auxiliary/SW Sea/Mercay Island/Mercay.json
@@ -7,7 +7,7 @@
       "chests": [
         {
           "name": "PickUpRock",
-          "type": "npc",
+          "type": "event",
           "contents": "small_green_rupee",
           "bmg_file_path": "English/Message/main_isl.bmg",
           "bmg_instruction_index": 135

--- a/shuffler/auxiliary/Sea.json
+++ b/shuffler/auxiliary/Sea.json
@@ -381,14 +381,14 @@
       "chests": [
         {
           "name": "NormalThing",
-          "type": "npc",
+          "type": "event",
           "contents": "",
           "bmg_file_path": "TODO",
           "bmg_instruction_index": -1
         },
         {
           "name": "MysteriousThing",
-          "type": "npc",
+          "type": "event",
           "contents": "",
           "bmg_file_path": "TODO",
           "bmg_instruction_index": -1


### PR DESCRIPTION
This is more fitting, because any BMG "event" can result in an item, not just an NPC interaction. It also makes the patcher terminology more consistent with the shuffler's.