### PR TITLE
Add pre-commit hook for validating aux data locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,12 @@ repos:
     rev: v14.0.6
     hooks:
     - id: clang-format
+
+  # Validate aux data against schema
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.18.4
+    hooks:
+      - id: check-jsonschema
+        files: ^shuffler/auxiliary/.*\.json$
+        args: ["--schemafile", "shuffler/aux_schema.json"]
+      - id: check-github-workflows


### PR DESCRIPTION
Allows aux data to be easily validated locally, instead of relying on CI. Also adds validator for github actions workflows, why not