### PR TITLE
Weaker pin requirements for dev-only dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,11 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest==7.2.0
-    pytest-repeat==0.9.1
-    pytest-xdist==3.1.0
+    pytest~=7.2.0
+    pytest-repeat~=0.9.1
+    pytest-xdist~=3.1.0
     py-desmume==0.0.5.post0
 
 types =
-    types-Pillow==9.4.0.2
-    types-setuptools==65.7.0.1
+    types-Pillow~=9.4.0.2
+    types-setuptools~=65.7.0.1


### PR DESCRIPTION
Hopefully this decreases the renovate bot spam.