### PR TITLE
Change default sword mode to randomized sword

### DIFF
--- a/ph_rando/settings.json
+++ b/ph_rando/settings.json
@@ -124,7 +124,7 @@
         "randomized_sword",
         "swordless"
       ],
-      "default": "start_with_sword",
+      "default": "randomized_sword",
       "supported": false
     },
     {


### PR DESCRIPTION
Randomized sword is the only supported mode currently. This may change in the future, but for now it doesn't make sense to default to an option that doesn't work properly.